### PR TITLE
tools: upgrade hecat to v1.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	python3 -m venv .venv
 	source .venv/bin/activate && \
 	pip3 install wheel && \
-	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.0.1 'sphinx<7'
+	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.0.2
 
 .PHONY: import # import data from original list at https://github.com/awesome-selfhosted/awesome-selfhosted
 import: clean install


### PR DESCRIPTION
- https://github.com/nodiscc/hecat/releases/tag/1.0.2
- remove manual sphinx installation as it is now correctly installed through setup_requires
