### PR TITLE
tools: github actions: fail/display red badge when unmaintained projects are detected

### DIFF
--- a/.github/workflows/check-unmaintained-projects.yml
+++ b/.github/workflows/check-unmaintained-projects.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make install
-      - run: make awesome_lint
+      - run: make awesome_lint_strict

--- a/.hecat/awesome-lint-strict.yml
+++ b/.hecat/awesome-lint-strict.yml
@@ -1,10 +1,12 @@
 # doc: https://github.com/nodiscc/hecat/blob/master/hecat/processors/awesome_lint.py
 steps:
-  - name: check data against awesome-selfhosted guidelines
+  - name: check data against awesome-selfhosted guidelines (strict)
     module: processors/awesome_lint
     module_options:
       source_directory: ./
       items_in_delegate_to_fatal: False
+      last_updated_error_days: 365
+      last_updated_warn_days: 186
       licenses_files:
         - licenses.yml
         - licenses-nonfree.yml

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	python3 -m venv .venv
 	source .venv/bin/activate && \
 	pip3 install wheel && \
-	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.0.2
+	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.1.0
 
 .PHONY: import # import data from original list at https://github.com/awesome-selfhosted/awesome-selfhosted
 import: clean install
@@ -29,6 +29,11 @@ update_metadata:
 awesome_lint:
 	source .venv/bin/activate && \
 	hecat --config .hecat/awesome-lint.yml
+
+.PHONY: awesome_lint # check data against awesome-selfhosted guidelines (strict)
+awesome_lint_strict:
+	source .venv/bin/activate && \
+	hecat --config .hecat/awesome-lint-strict.yml
 
 .PHONY: export_markdown # render markdown export from YAML data (https://github.com/awesome-selfhosted/awesome-selfhosted)
 export_markdown:


### PR DESCRIPTION
- lower error/warning days threshold, but only for the scheduled/daily check (leave thresholds unchanged for pull requests/pre-build checks)
- error if 365 days without updated, warning if 186 days without updates
- update hecat to v1.1.0 https://github.com/nodiscc/hecat/releases/tag/1.1.0
- fixes https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/50
