### PR TITLE
tools/github actions: build: always check out the latest commit of the branch that triggered the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - run: make install
       - run: make awesome_lint
       - run: make export_markdown
@@ -47,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - run: make install
       - run: make awesome_lint
       - run: make export_html


### PR DESCRIPTION
- without this, the commit that would be checked out would be the one that triggered the workflow
- when called from the needs: keyword in daily-update-metadata.yml, the build would run from the version prior to automatic metadata update/commit back to the repository
