### PR TITLE
contributing: link to awesome-selfhosted liberapay account

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ To do this from Github's web interface:
 
 ### Domain name costs
 
-You can help covering domain name registration and renewal costs by pledging a small amount on [Liberapay ![](https://img.shields.io/liberapay/goal/awesome-selfhosted?logo=liberapay) ![](https://img.shields.io/liberapay/receives/awesome-selfhosted?logo=liberapay)](https://liberapay.com/awesome-selfhosted/)
+You can help cover domain name registration and renewal costs by pledging a small amount on [Liberapay ![](https://img.shields.io/liberapay/goal/awesome-selfhosted?logo=liberapay) ![](https://img.shields.io/liberapay/receives/awesome-selfhosted?logo=liberapay)](https://liberapay.com/awesome-selfhosted/)
 
 
 ### Other

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,11 @@ To do this from Github's web interface:
 - In the `Commit changes` dialog, enter `Remove SOFTWARE_NAME (reason)` as your commit message, additional context in the `extended description` field, select `Create a new branch for this commit and start a pull request.`, and click `Commit Changes`
 
 
+### Domain name costs
+
+You can help covering domain name registration and renewal costs by pledging a small amount on [Liberapay ![](https://img.shields.io/liberapay/goal/awesome-selfhosted?logo=liberapay) ![](https://img.shields.io/liberapay/receives/awesome-selfhosted?logo=liberapay)](https://liberapay.com/awesome-selfhosted/)
+
+
 ### Other
 
 **Rename a tag/category:** the tag must be renamed in the appropriate `tags/mytag.yml` file. All references to it must be updated in `tags/*.yml` and `software/*.yml`.


### PR DESCRIPTION
I have set up a [Liberapay account](https://liberapay.com/awesome-selfhosted/) for awesome-selfhosted. The goal is set to 0.26€/week which equals the cost of domain name renewal for one year at Namecheap, divided by 52 weeks (13,73÷52=0.264038462).

![](https://img.shields.io/liberapay/goal/awesome-selfhosted?logo=liberapay) ![](https://img.shields.io/liberapay/receives/awesome-selfhosted?logo=liberapay)

Server rental costs (Ionos VPS M, 6€/month) are not included in the goal, since I also use this server for other purposes, though my share is set up to 1.76€/week if this sum is available ((13,73÷52) + (6÷4)=1.764038462). Any remaining funds will be left on the account for max ~1 year, then donated to the Debian project.

I hereby commit to never try to monetize this project, and to keep any financial interests away from it.