### PR TITLE
remove transfer.sh homepage link (no such domain)

### DIFF
--- a/software/transfer.sh.yml
+++ b/software/transfer.sh.yml
@@ -1,5 +1,5 @@
 name: transfer.sh
-website_url: https://transfer.sh
+website_url: https://github.com/dutchcoders/transfer.sh
 description: Easy file sharing from the command line.
 licenses:
   - MIT


### PR DESCRIPTION
- ref. #1 
- `https://transfer.sh : HTTPSConnectionPool(host='transfer.sh', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f82d5269180>: Failed to resolve 'transfer.sh' ([Errno -2] Name or service not known)"))`
- ref. https://github.com/dutchcoders/transfer.sh/issues/575
