### PR TITLE
Update Lynx demo URL

### DIFF
--- a/software/lynx.yml
+++ b/software/lynx.yml
@@ -9,7 +9,7 @@ platforms:
 tags:
   - URL Shorteners
 source_code_url: https://github.com/Lynx-Shortener/Lynx
-demo_url: https://demo.jck.cx
+demo_url: https://demo.getlynx.dev
 stargazers_count: 76
 updated_at: '2023-08-21'
 archived: false


### PR DESCRIPTION
Updates the demo URL from one of my personal domains to the lynx one. Both are the same instance, just a different domain.