### PR TITLE
platforms: add `deb` platform for software that can be installed trough .deb packages

### DIFF
--- a/platforms/deb.yml
+++ b/platforms/deb.yml
@@ -1,0 +1,2 @@
+name: deb
+description: "[deb](https://en.wikipedia.org/wiki/Deb_(file_format)) is the standard package format for Debian GNU/Linux and its derivatives."

--- a/software/asterisk.yml
+++ b/software/asterisk.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C
+  - deb
 tags:
   - Communication - SIP
 source_code_url: https://github.com/asterisk/asterisk

--- a/software/courier-mta.yml
+++ b/software/courier-mta.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-3.0
 platforms:
   - C
+  - deb
 tags:
   - Communication - Email - Mail Transfer Agents
 source_code_url: https://www.courier-mta.org/repo.html

--- a/software/dovecot.yml
+++ b/software/dovecot.yml
@@ -6,6 +6,7 @@ licenses:
   - LGPL-2.1
 platforms:
   - C
+  - deb
 tags:
   - Communication - Email - Mail Delivery Agents
 source_code_url: https://github.com/dovecot/core

--- a/software/exim.yml
+++ b/software/exim.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-3.0
 platforms:
   - C
+  - deb
 tags:
   - Communication - Email - Mail Transfer Agents
 source_code_url: https://git.exim.org/exim.git

--- a/software/iodine.yml
+++ b/software/iodine.yml
@@ -5,6 +5,7 @@ licenses:
   - ISC
 platforms:
   - C
+  - deb
 tags:
   - Proxy
 source_code_url: https://github.com/yarrick/iodine

--- a/software/jellyfin.yml
+++ b/software/jellyfin.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C#
+  - deb
 tags:
   - Media Streaming - Multimedia Streaming
 source_code_url: https://github.com/jellyfin/jellyfin

--- a/software/jitsi-meet.yml
+++ b/software/jitsi-meet.yml
@@ -6,6 +6,7 @@ licenses:
 platforms:
   - Nodejs
   - Docker
+  - deb
 tags:
   - Communication - Video Conferencing
 source_code_url: https://github.com/jitsi/jitsi-meet

--- a/software/jitsi-video-bridge.yml
+++ b/software/jitsi-video-bridge.yml
@@ -5,6 +5,7 @@ licenses:
   - Apache-2.0
 platforms:
   - Java
+  - deb
 tags:
   - Communication - Video Conferencing
 source_code_url: https://github.com/jitsi/jitsi-videobridge

--- a/software/kamailio.yml
+++ b/software/kamailio.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C
+  - deb
 tags:
   - Communication - SIP
 source_code_url: https://github.com/kamailio/kamailio

--- a/software/mumble.yml
+++ b/software/mumble.yml
@@ -5,6 +5,7 @@ licenses:
   - BSD-3-Clause
 platforms:
   - C++
+  - deb
 tags:
   - Communication - Custom Communication Systems
 source_code_url: https://github.com/mumble-voip/mumble

--- a/software/nextcloud.yml
+++ b/software/nextcloud.yml
@@ -5,6 +5,7 @@ licenses:
   - AGPL-3.0
 platforms:
   - PHP
+  - deb
 tags:
   - File Transfer & Synchronization
 source_code_url: https://github.com/nextcloud/server

--- a/software/ngircd.yml
+++ b/software/ngircd.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C
+  - deb
 tags:
   - Communication - IRC
 source_code_url: https://github.com/ngircd/ngircd

--- a/software/opensmtpd.yml
+++ b/software/opensmtpd.yml
@@ -5,6 +5,7 @@ licenses:
   - ISC
 platforms:
   - C
+  - deb
 tags:
   - Communication - Email - Mail Transfer Agents
 source_code_url: https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.sbin/smtpd/

--- a/software/openssh-sftp-server.yml
+++ b/software/openssh-sftp-server.yml
@@ -5,6 +5,7 @@ licenses:
   - BSD-2-Clause
 platforms:
   - C
+  - deb
 tags:
   - File Transfer & Synchronization
 source_code_url: https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/

--- a/software/postfix.yml
+++ b/software/postfix.yml
@@ -5,6 +5,7 @@ licenses:
   - IPL-1.0
 platforms:
   - C
+  - deb
 tags:
   - Communication - Email - Mail Transfer Agents
 source_code_url: http://www.postfix.org/

--- a/software/privoxy.yml
+++ b/software/privoxy.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C
+  - deb
 tags:
   - Proxy
 source_code_url: https://www.privoxy.org

--- a/software/roundcube.yml
+++ b/software/roundcube.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-3.0
 platforms:
   - PHP
+  - deb
 tags:
   - Communication - Email - Webmail Clients
 source_code_url: https://github.com/roundcube/roundcubemail

--- a/software/sendmail.yml
+++ b/software/sendmail.yml
@@ -5,6 +5,7 @@ licenses:
   - Sendmail
 platforms:
   - C
+  - deb
 tags:
   - Communication - Email - Mail Transfer Agents
 source_code_url: https://www.proofpoint.com/us/products/email-protection/open-source-email-solution

--- a/software/shaarli.yml
+++ b/software/shaarli.yml
@@ -5,6 +5,7 @@ licenses:
   - Zlib
 platforms:
   - PHP
+  - deb
 tags:
   - Bookmarks and Link Sharing
 source_code_url: https://github.com/shaarli/Shaarli

--- a/software/squid.yml
+++ b/software/squid.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C
+  - deb
 tags:
   - Proxy
 source_code_url: https://code.launchpad.net/squid

--- a/software/tinyproxy.yml
+++ b/software/tinyproxy.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - C
+  - deb
 tags:
   - Proxy
 source_code_url: https://github.com/tinyproxy/tinyproxy

--- a/software/transmission.yml
+++ b/software/transmission.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-3.0
 platforms:
   - C++
+  - deb
 tags:
   - File Transfer - Peer-to-peer Filesharing
 source_code_url: https://github.com/transmission/transmission

--- a/software/weechat.yml
+++ b/software/weechat.yml
@@ -6,6 +6,7 @@ licenses:
 platforms:
   - C
   - Docker
+  - deb
 tags:
   - Communication - IRC
 source_code_url: https://github.com/weechat/weechat

--- a/software/zim.yml
+++ b/software/zim.yml
@@ -5,6 +5,7 @@ licenses:
   - GPL-2.0
 platforms:
   - Python
+  - deb
 tags:
   - Wikis
 source_code_url: https://github.com/zim-desktop-wiki/zim-desktop-wiki

--- a/software/znc.yml
+++ b/software/znc.yml
@@ -5,6 +5,7 @@ licenses:
   - Apache-2.0
 platforms:
   - C++
+  - deb
 tags:
   - Communication - IRC
 source_code_url: https://github.com/znc/znc


### PR DESCRIPTION
- this platform may be added to software that is installable through .deb packages/repositories (either official Debian repositories, or repositories/.deb packages provided by project maintainers)
- related https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/71
- added the platform to a few items (not exhaustive)
