### PR TITLE
tests/url-check: whitelist Memories demo URL

### DIFF
--- a/.hecat/url-check.yml
+++ b/.hecat/url-check.yml
@@ -24,3 +24,4 @@ steps:
         - '^https://demo.reservo.co/$' # hecat/python-requests bug? always returns 404 but the website works in a browser
         - '^https://crates.io/crates/vigil-server$' # hecat/python-requests bug? always returns 404 but the website works in a browser
         - '^https://nitter.net$' # always times out from github actions but the website works in a browser
+        - '^https://demo.memories.gallery/apps/memories/$' # always returns 401


### PR DESCRIPTION
- always returns HTTP 401 before accessing the actual demo page
- ref. #1