### PR TITLE
tools/hecat: fail when a software item has a tag for which `redirect` is set

### DIFF
--- a/.hecat/awesome-lint.yml
+++ b/.hecat/awesome-lint.yml
@@ -4,7 +4,6 @@ steps:
     module: processors/awesome_lint
     module_options:
       source_directory: ./
-      items_in_delegate_to_fatal: False
       licenses_files:
         - licenses.yml
         - licenses-nonfree.yml


### PR DESCRIPTION
- https://github.com/nodiscc/hecat/blob/master/hecat/processors/awesome_lint.py#L11
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/163
