### PR TITLE
rename Hoppscotch to Hoppscotch Community Edition

### DIFF
--- a/platforms/nuxt.yml
+++ b/platforms/nuxt.yml
@@ -1,2 +1,0 @@
-name: Nuxt
-description: ""

--- a/platforms/vue.yml
+++ b/platforms/vue.yml
@@ -1,2 +1,0 @@
-name: Vue
-description: ""

--- a/software/hoppscotch.yml
+++ b/software/hoppscotch.yml
@@ -1,12 +1,11 @@
-name: Hoppscotch
+name: Hoppscotch Community Edition
 website_url: https://hoppscotch.io
 description: A free, fast and beautiful API request builder.
 licenses:
   - MIT
 platforms:
   - Nodejs
-  - Vue
-  - Nuxt
+  - Docker
 tags:
   - Software Development - API Management
 source_code_url: https://github.com/hoppscotch/hoppscotch


### PR DESCRIPTION
- Community Edition is the only MIT-licensed edition
- Cleanup platforms/languages (https://docs.hoppscotch.io/documentation/self-host/community-edition/getting-started)
