### PR TITLE
Fix SIP3 platform

### DIFF
--- a/platforms/kotlin.yml
+++ b/platforms/kotlin.yml
@@ -1,2 +1,0 @@
-name: Kotlin
-description: ""

--- a/software/sip3.yml
+++ b/software/sip3.yml
@@ -4,7 +4,7 @@ description: VoIP troubleshooting and monitoring platform.
 licenses:
   - Apache-2.0
 platforms:
-  - Kotlin
+  - Java
 tags:
   - Communication - SIP
 source_code_url: https://github.com/sip3io/


### PR DESCRIPTION
- written in kotlin but runs through a Java runtime https://github.com/sip3io/sip3-ansible/blob/master/roles/salto/tasks/debian.yml#L6
- Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects.
