### PR TITLE
rename Nimble platform to Nim

### DIFF
--- a/platforms/nim.yml
+++ b/platforms/nim.yml
@@ -1,0 +1,2 @@
+name: Nim
+description: "[Nim](https://en.wikipedia.org/wiki/Nim_(programming_language)) is a general-purpose, multi-paradigm, statically typed, compiled high-level systems programming language"

--- a/platforms/nimble.yml
+++ b/platforms/nimble.yml
@@ -1,2 +1,0 @@
-name: Nimble
-description: ""

--- a/software/nitter.yml
+++ b/software/nitter.yml
@@ -4,7 +4,7 @@ description: A alternative front end to twitter.
 licenses:
   - AGPL-3.0
 platforms:
-  - Nimble
+  - Nim
   - Docker
 tags:
   - Communication - Social Networks and Forums


### PR DESCRIPTION
- Nim is the actual name of the language, Nimble is the package manager for Nim
- add platform description
