### PR TITLE
group Calendar & Contacts Servers/Web-based clients under a single Calendar & Contacts section

### DIFF
--- a/.github/ISSUE_TEMPLATE/addition.md
+++ b/.github/ISSUE_TEMPLATE/addition.md
@@ -35,7 +35,7 @@ platforms:
 # list of tags (categories), see https://github.com/awesome-selfhosted/awesome-selfhosted-data/tree/master/tags for the full list of tags
 tags:
   - Automation
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
   - Bookmarks and Link Sharing
   - Pastebins
 # (optional, yes/no, default no) whether the software depends on a third-party service outside the user's control

--- a/software/baïkal.yml
+++ b/software/baïkal.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - PHP
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://github.com/sabre-io/Baikal
 stargazers_count: 2188
 updated_at: '2023-07-15'

--- a/software/calypso.yml
+++ b/software/calypso.yml
@@ -6,5 +6,5 @@ licenses:
 platforms:
   - Python
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://keithp.com/cgit/

--- a/software/davical.yml
+++ b/software/davical.yml
@@ -6,5 +6,5 @@ licenses:
 platforms:
   - PHP
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://gitlab.com/davical-project/davical

--- a/software/davis.yml
+++ b/software/davis.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - PHP
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://github.com/tchapi/davis
 stargazers_count: 231
 updated_at: '2023-09-10'

--- a/software/etebase-etesync.yml
+++ b/software/etebase-etesync.yml
@@ -7,7 +7,7 @@ platforms:
   - Python
   - Django
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://github.com/etesync/server
 stargazers_count: 1364
 updated_at: '2023-08-16'

--- a/software/etesync-web.yml
+++ b/software/etesync-web.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - Javascript
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Web-based Clients
+  - Calendar & Contacts
 source_code_url: https://github.com/etesync/etesync-web
 demo_url: https://client.etesync.com/
 stargazers_count: 230

--- a/software/manage-my-damn-life.yml
+++ b/software/manage-my-damn-life.yml
@@ -7,7 +7,7 @@ platforms:
   - Nodejs
   - Docker
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Web-based Clients
+  - Calendar & Contacts
 source_code_url: https://github.com/intri-in/manage-my-damn-life-nextjs
 stargazers_count: 57
 updated_at: '2023-08-13'

--- a/software/radicale.yml
+++ b/software/radicale.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - Python
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://github.com/Kozea/Radicale
 stargazers_count: 2862
 updated_at: '2023-04-22'

--- a/software/sabredav.yml
+++ b/software/sabredav.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - PHP
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://github.com/sabre-io/dav
 stargazers_count: 1411
 updated_at: '2023-07-31'

--- a/software/xandikos.yml
+++ b/software/xandikos.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - Python
 tags:
-  - Calendar & Contacts - CalDAV or CardDAV Servers
+  - Calendar & Contacts
 source_code_url: https://github.com/jelmer/xandikos
 stargazers_count: 316
 updated_at: '2023-09-06'

--- a/tags/calendar--contacts---caldav-or-carddav-servers.yml
+++ b/tags/calendar--contacts---caldav-or-carddav-servers.yml
@@ -1,5 +1,5 @@
-name: Calendar & Contacts - CalDAV or CardDAV Servers
-description: '[CalDAV](https://en.wikipedia.org/wiki/CalDAV) and [CardDAV](https://en.wikipedia.org/wiki/CardDAV) protocol servers [Electronic calendar](https://en.wikipedia.org/wiki/Calendaring_software) and [address book](https://en.wikipedia.org/wiki/Address_book) and [contact management](https://en.wikipedia.org/wiki/Contact_manager).'
+name: Calendar & Contacts
+description: '[CalDAV](https://en.wikipedia.org/wiki/CalDAV) and [CardDAV](https://en.wikipedia.org/wiki/CardDAV) protocol servers and web clients/interfaces for [Electronic calendar](https://en.wikipedia.org/wiki/Calendaring_software), [address book](https://en.wikipedia.org/wiki/Address_book) and [contact management](https://en.wikipedia.org/wiki/Contact_manager).'
 external_links:
   - title: Comparison of CalDAV and CardDAV implementations - Wikipedia
     url: https://en.wikipedia.org/wiki/Comparison_of_CalDAV_and_CardDAV_implementations

--- a/tags/calendar--contacts---caldav-or-carddav-web-based-clients.yml
+++ b/tags/calendar--contacts---caldav-or-carddav-web-based-clients.yml
@@ -1,2 +1,0 @@
-name: Calendar & Contacts - CalDAV or CardDAV Web-based Clients
-description: '[CalDAV](https://en.wikipedia.org/wiki/CalDAV) and [CardDAV](https://en.wikipedia.org/wiki/CardDAV) protocol web clients/interfaces.'


### PR DESCRIPTION
- since the removal of AgenDav in https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/145, these no longer pass the check
- ERROR:awesome_lint.py: 2 items tagged Calendar & Contacts - CalDAV or CardDAV Web-based Clients, each tag must have at least 3 items attached
