### PR TITLE
fix SIPCAPTURE HOMPER language/platform

### DIFF
--- a/platforms/angular.yml
+++ b/platforms/angular.yml
@@ -1,2 +1,0 @@
-name: Angular
-description: ""

--- a/software/sipcapture-homer.yml
+++ b/software/sipcapture-homer.yml
@@ -4,8 +4,9 @@ description: Troubleshooting and monitoring VoIP calls.
 licenses:
   - AGPL-3.0
 platforms:
-  - Angular
-  - C
+  - Nodejs
+  - Go
+  - Docker
 tags:
   - Communication - SIP
 source_code_url: https://github.com/sipcapture/homer


### PR DESCRIPTION
- all submodules in https://github.com/sipcapture/homer point to repositories written in Go chich compile to static binaries
- https://github.com/sipcapture/homer-ui/ mentions npm
