### PR TITLE
Fix Guacamole source code

### DIFF
--- a/software/guacamole.yml
+++ b/software/guacamole.yml
@@ -8,4 +8,4 @@ platforms:
   - C
 tags:
   - Remote Access
-source_code_url: https://github.com/glyptodon/
+source_code_url: https://github.com/apache/guacamole-server


### PR DESCRIPTION
- Guacamole was donated to the [Apache Software Foundation](http://apache.org/) in 2016 and is now [Apache Guacamole}(https://guacamole.apache.org/)
- Repo is archived