### PR TITLE
fix Upsnap platform

### DIFF
--- a/platforms/svelte.yml
+++ b/platforms/svelte.yml
@@ -1,2 +1,0 @@
-name: Svelte
-description: ""

--- a/software/upsnap.yml
+++ b/software/upsnap.yml
@@ -4,7 +4,6 @@ description: A simple Wake on LAN (WOL) dashboard app. Wake up devices on your n
 licenses:
   - MIT
 platforms:
-  - Svelte
   - Go
   - Docker
 tags:


### PR DESCRIPTION
- the backend is written in Go and can be installed as a static binary
