### PR TITLE
Change DailyTxt tag to Note-taking & Editors

### DIFF
--- a/software/dailytxt.yml
+++ b/software/dailytxt.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - Docker
 tags:
-  - Miscellaneous
+  - Note-taking & Editors
 source_code_url: https://github.com/PhiTux/DailyTxT
 stargazers_count: 153
 updated_at: '2023-07-13'

--- a/software/dailytxt.yml
+++ b/software/dailytxt.yml
@@ -1,6 +1,6 @@
 name: DailyTxT
 website_url: https://github.com/PhiTux/DailyTxT
-description: Encrypted Diary Web-App to save your personal memories of each day. Includes a search-function and encrypted file-upload.
+description: Encrypted diary Web application to save your personal memories of each day. Includes a search function and encrypted file upload.
 licenses:
   - MIT
 platforms:


### PR DESCRIPTION
> DailyTxT is an encrypted Diary Web-App to write down your stories of the day and to find them again easily.
