### PR TITLE
Change Wallabag tag to Archiving and Digital Preservation (DP)

### DIFF
--- a/software/wallabag.yml
+++ b/software/wallabag.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - PHP
 tags:
-  - Miscellaneous
+  - Archiving and Digital Preservation (DP)
 source_code_url: https://github.com/wallabag/wallabag
 stargazers_count: 8955
 updated_at: '2023-10-03'


### PR DESCRIPTION
> wallabag is a self hostable application for saving web pages: Save and classify articles. Read them later.
