### PR TITLE
Update URL for Tiki source code

### DIFF
--- a/software/tiki.yml
+++ b/software/tiki.yml
@@ -7,5 +7,5 @@ platforms:
   - PHP
 tags:
   - Wikis
-source_code_url: https://sourceforge.net/p/tikiwiki/code/HEAD/tree/
+source_code_url: https://gitlab.com/tikiwiki/tiki
 demo_url: https://tiki.org/Try-Tiki


### PR DESCRIPTION
Thank you SourceForge for all the support over the years.

https://dev.tiki.org/Tiki-Version-control-history