### PR TITLE
tools: update hecat to v1.2.0 (#261)

### DIFF
--- a/.hecat/conf.py
+++ b/.hecat/conf.py
@@ -15,6 +15,7 @@ html_show_copyright = True
 html_use_opensearch = 'https://awesome-selfhosted.net/'
 html_favicon = '../_static/favicon.ico'
 html_logo = '../_static/logo.svg'
+html_css_files = ['custom.css']
 extensions = ['myst_parser', 'sphinx_design']
 source_suffix = ['.md']
 templates_path = ['_templates']

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	python3 -m venv .venv
 	source .venv/bin/activate && \
 	pip3 install wheel && \
-	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.1.3
+	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.2.0
 
 .PHONY: import # import data from original list at https://github.com/awesome-selfhosted/awesome-selfhosted
 import: clean install


### PR DESCRIPTION
Second attempt at https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/261, adding the `html_css_files` sphinx configuration option required for CSS styling to work. (https://github.com/nodiscc/hecat/releases/tag/1.2.0)

- https://github.com/nodiscc/hecat/releases/tag/1.2.0
- fixes https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/71 (a subpage will be generated for each `platform` (e.g. https://awesome-selfhosted.net/platforms/docker.html - due to this change all items in `platforms/*.yml` must now have a non-empty `description` attribute)
- fixes https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/116 (inline CSS was moved to an external file and longer shows up in the search results)
- related https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/78
- add required html_css_files sphinx configuration option
