### PR TITLE
Update Umami Demo Link

### DIFF
--- a/software/umami.yml
+++ b/software/umami.yml
@@ -9,7 +9,7 @@ platforms:
 tags:
   - Analytics
 source_code_url: https://github.com/umami-software/umami
-demo_url: https://app.umami.is/share/8rmHaheU/umami.is
+demo_url: https://analytics.umami.is/share/LGazGOecbDtaIwDr/umami.is
 stargazers_count: 17138
 updated_at: '2023-09-23'
 archived: false


### PR DESCRIPTION
Old link was 404ing 

This seems to be the new demo link directed from https://umami.is