### PR TITLE
Update Galette website URL

### DIFF
--- a/software/galette.yml
+++ b/software/galette.yml
@@ -1,5 +1,5 @@
 name: Galette
-website_url: https://galette.eu/dc/
+website_url: https://galette.eu/
 description: Galette is a membership management web application towards non profit organizations.
 licenses:
   - GPL-3.0


### PR DESCRIPTION
- ref. #1
```
https://git.tuxfamily.org/galette/galette.git/ : HTTPSConnectionPool(host='git.tuxfamily.org', port=443): Max retries exceeded with url: /galette/galette.git/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f975ce81960>: Failed to establish a new connection: [Errno 101] Network is unreachable'))
https://galette.eu/dc/ : HTTPSConnectionPool(host='galette.eu', port=443): Max retries exceeded with url: /dc/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f975ce81d20>: Failed to establish a new connection: [Errno 101] Network is unreachable'))
```
