### PR TITLE
Adds DocKing to Document Management

### DIFF
--- a/software/docking.yml
+++ b/software/docking.yml
@@ -1,0 +1,15 @@
+name: DocKing
+website_url: https://docking.shipsaas.tech
+description: Your shared-microservice that takes over the document templates management & render/export PDF dynamically.
+licenses:
+  - MIT
+platforms:
+  - PHP
+  - Javascript
+  - Docker
+tags:
+  - Document Management
+source_code_url: https://github.com/shipsaas/docking
+stargazers_count: 69
+updated_at: '2023-10-29'
+archived: false

--- a/software/docking.yml
+++ b/software/docking.yml
@@ -10,6 +10,7 @@ platforms:
 tags:
   - Document Management
 source_code_url: https://github.com/shipsaas/docking
+demo_url: https://docking-demo.shipsaas.tech/console
 stargazers_count: 69
 updated_at: '2023-10-29'
 archived: false

--- a/software/docking.yml
+++ b/software/docking.yml
@@ -11,6 +11,4 @@ tags:
   - Document Management
 source_code_url: https://github.com/shipsaas/docking
 demo_url: https://docking-demo.shipsaas.tech/console
-stargazers_count: 69
-updated_at: '2023-10-29'
-archived: false
+

--- a/software/docking.yml
+++ b/software/docking.yml
@@ -11,4 +11,3 @@ tags:
   - Document Management
 source_code_url: https://github.com/shipsaas/docking
 demo_url: https://docking-demo.shipsaas.tech/console
-

--- a/software/docking.yml
+++ b/software/docking.yml
@@ -1,6 +1,6 @@
 name: DocKing
 website_url: https://docking.shipsaas.tech
-description: Your shared-microservice that takes over the document templates management & render/export PDF dynamically.
+description: Document management service/microservice that handles templates and renders them in PDF format, all in one place.
 licenses:
   - MIT
 platforms:

--- a/software/docking.yml
+++ b/software/docking.yml
@@ -5,7 +5,7 @@ licenses:
   - MIT
 platforms:
   - PHP
-  - Javascript
+  - Nodejs
   - Docker
 tags:
   - Document Management


### PR DESCRIPTION
Hi team, DocKing is 4+ months old and I'd like to add this to our lovely list of self-hosted software.

DocKing is free, fully open-sourced. Helps us to centralize document templates & handle render/export PDFs dynamically.

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. 
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] If you are adding software forked from another active project, please provide/link to a clear list of differences between both.
- [x] You understand that your Pull Request will be merged ~1 week after approval, to allow for further comments if needed.
