### PR TITLE
Inlets is proprietary now :(

### DIFF
--- a/software/inlets.yml
+++ b/software/inlets.yml
@@ -8,4 +8,4 @@ platforms:
   - Docker
 tags:
   - Proxy
-source_code_url: https://inlets.dev/
+source_code_url: https://github.com/inlets/inlets-pro

--- a/software/inlets.yml
+++ b/software/inlets.yml
@@ -2,7 +2,7 @@ name: inlets
 website_url: https://inlets.dev/
 description: Expose your local endpoints to the Internet - with a Kubernetes integration, Docker image and CLI available.
 licenses:
-  - Proprietary
+  - ⊘ Proprietary
 platforms:
   - Go
   - Docker

--- a/software/inlets.yml
+++ b/software/inlets.yml
@@ -2,7 +2,7 @@ name: inlets
 website_url: https://inlets.dev/
 description: Expose your local endpoints to the Internet - with a Kubernetes integration, Docker image and CLI available.
 licenses:
-  - MIT
+  - Proprietary
 platforms:
   - Go
   - Docker


### PR DESCRIPTION
Inlets is now proprietary software not 100% licensed under the MIT license, and can no longer be selfhosted for free. Selfhosting licenses can be acquired for a price, which is why I'm not removing the file altogether.