### PR TITLE
StartOS is now MIT

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git-blame.gitWebUrl": ""
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git-blame.gitWebUrl": ""
+}

--- a/software/startos.yml
+++ b/software/startos.yml
@@ -1,8 +1,8 @@
 name: StartOS
 website_url: https://start9.com
-description: ' Browser-based, graphical operating system for a personal server.'
+description: 'Browser-based, graphical Operating System (OS) that makes running a personal server as easy as running a personal computer.'
 licenses:
-  - ⊘ Proprietary
+  - MIT
 platforms:
   - Rust
 tags:


### PR DESCRIPTION
Minor edit to reflect that StartOS is now FLOSS (MIT), please ensure that this is moved to the main list and away from the scarlet letter of "proprietary," if not done programmatically. 

Thank you for your time