### PR TITLE
Added links to URL Check and Removed Psychic  URL

### DIFF
--- a/.hecat/url-check.yml
+++ b/.hecat/url-check.yml
@@ -34,3 +34,5 @@ steps:
         - '^https://www.zenphoto.org/' # always times out from github actions but the website works in a browser
         - '^https://alextselegidis.com/try/plainpad/' # shows 200 when curling, loads fine in browser
         - '^https://alextselegidis.com/get/plainpad/' # shows 200 when curling, loads fine in browser
+        - '^http://www.openwebanalytics.com/' # shows 200 when curling, loads fine in browser
+        - '^https://moodle.org/' # shows 200 when curling, loads fine in browser

--- a/software/psychic.yml
+++ b/software/psychic.yml
@@ -1,5 +1,5 @@
 name: Psychic
-website_url: https://www.psychic.dev/
+website_url: https://github.com/psychic-api/psychic
 description: Universal API to connect large language models to dynamic data sources.
 licenses:
   - GPL-3.0


### PR DESCRIPTION
Added Moodle and Open Web Analytics
Rmoved Psychic Dev URL

All links have been showing isses for the past week ish. It looks like moodle is not a temporary issue as hoped!