### PR TITLE
Update Alfresco Community source code link

### DIFF
--- a/software/alfresco-community-edition.yml
+++ b/software/alfresco-community-edition.yml
@@ -7,4 +7,4 @@ platforms:
   - Java
 tags:
   - Content Management Systems (CMS)
-source_code_url: https://hub.alfresco.com/t5/alfresco-content-services-hub/project-overview-repository/ba-p/290502
+source_code_url: https://github.com/Alfresco/alfresco-community-repo


### PR DESCRIPTION
Most components listed at the previous URL have been grouped to the new unified repository
