### PR TITLE
Remove depends_3rdparty for Flyimg project

### DIFF
--- a/software/flyimg.yml
+++ b/software/flyimg.yml
@@ -8,7 +8,6 @@ platforms:
   - Docker
 tags:
   - Miscellaneous
-depends_3rdparty: no
 demo_url: https://demo.flyimg.io
 stargazers_count: 834
 updated_at: '2023-10-30'


### PR DESCRIPTION
Remove depends_3rdparty for Flyimg project to remove the flag ⚠ Anti-features