### PR TITLE
tools: exclude Simple-URL-Shortener from last update checks

### DIFF
--- a/.hecat/awesome-lint-strict.yml
+++ b/.hecat/awesome-lint-strict.yml
@@ -15,3 +15,4 @@ steps:
         - https://github.com/abrenaut/posio # simple/no maintenance required
         - https://github.com/knrdl/bicimon # simple/no maintenance required
         - https://github.com/Kshitij-Banerjee/Cubiks-2048 # simple/no maintenance required
+        - https://github.com/azlux/Simple-URL-Shortener # simple/no maintenance required

--- a/.hecat/awesome-lint.yml
+++ b/.hecat/awesome-lint.yml
@@ -12,3 +12,4 @@ steps:
         - https://github.com/abrenaut/posio # simple/no maintenance required
         - https://github.com/knrdl/bicimon # simple/no maintenance required
         - https://github.com/Kshitij-Banerjee/Cubiks-2048 # simple/no maintenance required
+        - https://github.com/azlux/Simple-URL-Shortener # simple/no maintenance required


### PR DESCRIPTION
- ref. #1
- simple/no maintenance required, 500 line PHP without dependencies

```
$ cloc Simple-URL-Shortener/
      17 text files.
      15 unique files.                              
       7 files ignored.

github.com/AlDanial/cloc v 1.96  T=0.04 s (420.2 files/s, 23640.8 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
PHP                              9             56             10            581
CSS                              4             20              6            103
Markdown                         1             12              0             52
JavaScript                       1              0              0              4
-------------------------------------------------------------------------------
SUM:                            15             88             16            740
-------------------------------------------------------------------------------
```