### PR TITLE
Update Budibase License

### DIFF
--- a/software/budibase.yml
+++ b/software/budibase.yml
@@ -2,7 +2,7 @@ name: Budibase
 website_url: https://www.budibase.com
 description: Build and automate internal tools, admin panels, dashboards, CRUD apps, and more, in minutes (alternative to Outsystems, Retool, Mendix, Appian).
 licenses:
-  - GPL-3.0
+  - ⊘ Proprietary
 platforms:
   - Nodejs
   - Docker


### PR DESCRIPTION
- Budibase cannot be built from GPL-3.0 sources https://github.com/Budibase/budibase/discussions/12377, https://github.com/Budibase/budibase/blob/master/LICENSE
- The next version will enforce an artificial limit on the number of users, which cannot be patched out https://budibase.com/blog/updates/pricing-v3/
