### PR TITLE
fix mailpiler homepage URL

### DIFF
--- a/software/piler.yml
+++ b/software/piler.yml
@@ -1,6 +1,6 @@
 name: Piler
-website_url: https://www.mailpiler.org/wiki/start
-description: Feature-rich open source email archiving solution.
+website_url: https://www.mailpiler.org/
+description: Feature-rich email archiving solution.
 licenses:
   - GPL-3.0
 platforms:


### PR DESCRIPTION
- replaces https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/400
- removed open source from description as all software listed here is FOSS
