### PR TITLE
remove bigbluebutton demo link

### DIFF
--- a/software/bigbluebutton.yml
+++ b/software/bigbluebutton.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Communication - Video Conferencing
 source_code_url: https://github.com/bigbluebutton/bigbluebutton
-demo_url: https://demo.bigbluebutton.org/gl
 stargazers_count: 8199
 updated_at: '2023-12-08'
 archived: false


### PR DESCRIPTION
- ref. #1
- link returns error 503
- https://demo.bigbluebutton.org/ has no way to access the demo without registering an account
