### PR TITLE
Update Synapse source code URL

### DIFF
--- a/software/synapse.yml
+++ b/software/synapse.yml
@@ -8,7 +8,7 @@ platforms:
   - deb
 tags:
   - Communication - Custom Communication Systems
-source_code_url: https://github.com/matrix-org/synapse
+source_code_url: https://github.com/element-hq/synapse
 stargazers_count: 11720
 updated_at: '2023-12-13'
 archived: true


### PR DESCRIPTION
> Synapse is now actively maintained at element-hq/synapse
