### PR TITLE
Update transfer.sh homepage URL

### DIFF
--- a/software/transfer.sh.yml
+++ b/software/transfer.sh.yml
@@ -1,5 +1,5 @@
 name: transfer.sh
-website_url: https://transfer.sh
+website_url: https://github.com/dutchcoders/transfer.sh
 description: Easy file sharing from the command line.
 licenses:
   - MIT


### PR DESCRIPTION
- https://transfer.sh is only mentioned as an example in the documentation
- ref. #1
- > `https://transfer.sh : HTTPSConnectionPool(host='transfer.sh', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f4c3ec57850>: Failed to establish a new connection: [Errno 101] Network is unreachable'))`
