### PR TITLE
Fix Demo URL of Uptime Kuma

### DIFF
--- a/software/uptime-kuma.yml
+++ b/software/uptime-kuma.yml
@@ -9,7 +9,7 @@ platforms:
 tags:
   - Status / Uptime pages
 source_code_url: https://github.com/louislam/uptime-kuma
-demo_url: https://demo.uptime.kuma.pet
+demo_url: https://demo.kuma.pet
 stargazers_count: 44030
 updated_at: '2024-01-08'
 archived: false


### PR DESCRIPTION
- `https://demo.uptime.kuma.pet/ : HTTPSConnectionPool(host='demo.uptime.kuma.pet', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f7cb200b910>: Failed to resolve 'demo.uptime.kuma.pet' ([Errno -5] No address associated with hostname)"))`
- They changed their Server and also their Domain with this, see https://github.com/louislam/uptime-kuma/pull/4296