### PR TITLE
Fix ZOT url

### DIFF
--- a/software/zotregistry.yml
+++ b/software/zotregistry.yml
@@ -1,5 +1,5 @@
 name: "ZOT OCI Registry"
-website_url: "https://zotregistry.io/"
+website_url: "https://zotregistry.dev/"
 source_code_url: "https://github.com/project-zot/zot"
 description: "A production-ready vendor-neutral OCI-native container image registry."
 licenses:


### PR DESCRIPTION
- `https://zotregistry.io/ : HTTPSConnectionPool(host='zotregistry.io', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fa2f7819f90>: Failed to resolve 'zotregistry.io' ([Errno -2] Name or service not known)"))`
- They moved their domain, as they failed to renew their old one (ref: https://github.com/project-zot/zot/issues/2157#issuecomment-1885459557)