### PR TITLE
Update ZOT Registry homepage link

### DIFF
--- a/software/zotregistry.yml
+++ b/software/zotregistry.yml
@@ -1,7 +1,7 @@
-name: "ZOT OCI Registry"
-website_url: "https://zotregistry.io/"
-source_code_url: "https://github.com/project-zot/zot"
-description: "A production-ready vendor-neutral OCI-native container image registry."
+name: ZOT OCI Registry
+website_url: https://zotregistry.dev
+source_code_url: https://github.com/project-zot/zot
+description: A production-ready vendor-neutral OCI-native container image registry.
 licenses:
   - Apache-2.0
 platforms:
@@ -9,4 +9,4 @@ platforms:
   - Docker
 tags:
   - File Transfer - Object Storage & File Servers
-demo_url: "https://zothub.io"
+demo_url: https://zothub.io


### PR DESCRIPTION
- ref. #1
- `https://zotregistry.io/ : HTTPSConnectionPool(host='zotregistry.io', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fa2f7819f90>: Failed to resolve 'zotregistry.io' ([Errno -2] Name or service not known)"))`