### PR TITLE
Update Bugzilla source Code URL

### DIFF
--- a/software/bugzilla.yml
+++ b/software/bugzilla.yml
@@ -7,4 +7,4 @@ platforms:
   - Perl
 tags:
   - Ticketing
-source_code_url: https://www.bugzilla.org/
+source_code_url: https://github.com/bugzilla/bugzilla


### PR DESCRIPTION
Use the actual source code URL. Folowed links through https://www.bugzilla.org/contributing/ - > https://wiki.mozilla.org/Bugzilla:Developers -> https://wiki.mozilla.org/Bugzilla:Git
