### PR TITLE
Update Calibre Source Code URL

### DIFF
--- a/software/calibre.yml
+++ b/software/calibre.yml
@@ -8,5 +8,5 @@ platforms:
   - deb
 tags:
   - Document Management - E-books
-source_code_url: https://launchpad.net/calibre
+source_code_url: https://github.com/kovidgoyal/calibre
 demo_url: https://calibre-ebook.com/demo


### PR DESCRIPTION
Point to the actual source code URL mentioned in https://calibre-ebook.com/get-involved
