### PR TITLE
Fix easyappointments demo uri

### DIFF
--- a/software/easy!appointments.yml
+++ b/software/easy!appointments.yml
@@ -8,7 +8,7 @@ platforms:
 tags:
   - Booking and Scheduling
 source_code_url: https://github.com/alextselegidis/easyappointments
-demo_url: https://easyappointments.org/demo/
+demo_url: https://demo.easyappointments.org/
 stargazers_count: 2955
 updated_at: '2023-12-04'
 archived: false


### PR DESCRIPTION
- `https://easyappointments.org/demo/ : HTTP 404`
- Demo got moved to an own subdomain