### PR TITLE
Update mattermost url

### DIFF
--- a/software/mattermost.yml
+++ b/software/mattermost.yml
@@ -1,5 +1,5 @@
 name: Mattermost
-website_url: https://mattermost.org/
+website_url: https://mattermost.com/
 description: Platform for secure collaboration across the entire software development lifecycle, can be integrated with Gitlab (alternative to Slack).
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1
- They moved their tld from .org to .com
- A redirect is currently still set-up