### PR TITLE
Remove Demo from Gogs

### DIFF
--- a/software/gogs.yml
+++ b/software/gogs.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Software Development - Project Management
 source_code_url: https://github.com/gogs/gogs
-demo_url: https://try.gogs.io/
 stargazers_count: 43701
 updated_at: '2024-01-01'
 archived: false


### PR DESCRIPTION
- ref: #1
- Issue regarding the unavailability of the Demo was reported in https://github.com/gogs/gogs/issues/7651
- Issue tracker does not seem to be maintained anymore ([#7601](https://github.com/gogs/gogs/issues/7601), [#7602](https://github.com/gogs/gogs/issues/7602), [#7643](https://github.com/gogs/gogs/issues/7643))
- Demo is unavailable since 2024-01-21
- `https://try.gogs.io/ : HTTPSConnectionPool(host='try.gogs.io', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f5c6d73b2b0>: Failed to establish a new connection: [Errno 101] Network is unreachable'))`