### PR TITLE
Adding docker tag for anonaddy

### DIFF
--- a/software/anonaddy.yml
+++ b/software/anonaddy.yml
@@ -5,6 +5,7 @@ licenses:
   - MIT
 platforms:
   - PHP
+  - Docker
 tags:
   - Communication - Email - Complete Solutions
 source_code_url: https://github.com/anonaddy/anonaddy


### PR DESCRIPTION
"For those who prefer using Docker there is an image you can use here - github.com/anonaddy/docker."

They provide an official docker image and link to it from their repository.