### PR TITLE
Create Grimoire

### DIFF
--- a/software/Grimoire
+++ b/software/Grimoire
@@ -1,0 +1,12 @@
+name: Grimoire
+website_url: hhttps://grimoire.pro/
+description: Bookmark manager for the wizards 🧙
+licenses:
+  - MIT
+platforms:
+tags:
+  - Bookmarks and Link Sharing
+source_code_url: https://github.com/goniszewski/
+stargazers_count: 6001
+updated_at: '2024-01-31'
+archived: false

--- a/software/Grimoire
+++ b/software/Grimoire
@@ -4,9 +4,16 @@ description: Bookmark manager for the wizards 🧙
 licenses:
   - MIT
 platforms:
+  - Docker
+  - Dockerfile
+  - Svelte
+  - Typescript
+  - Javascript
+  - HTML
+  - Shell
 tags:
   - Bookmarks and Link Sharing
 source_code_url: https://github.com/goniszewski/
-stargazers_count: 6001
+stargazers_count: 1300
 updated_at: '2024-01-31'
 archived: false


### PR DESCRIPTION
Add Grimoire to Bookmarks and Link Sharing section

<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->

Thanks for taking the time to suggest an addition to awesome-selfhosted! 

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. 
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged ~1 week after approval, to allow for further comments if needed.
