### PR TITLE
Update Demo of ArchivesSpace

### DIFF
--- a/software/archivesspace.yml
+++ b/software/archivesspace.yml
@@ -8,7 +8,7 @@ platforms:
 tags:
   - Archiving and Digital Preservation (DP)
 source_code_url: https://github.com/archivesspace/archivesspace
-demo_url: https://archivesspace.org/application/demo
+demo_url: https://archivesspace.org/application/sandbox
 stargazers_count: 315
 updated_at: '2024-01-11'
 archived: false


### PR DESCRIPTION
- ref: #1 
- Update Link which leads to ArchivesSpace Demo to the new URL
- `https://archivesspace.org/application/demo : HTTP 404`