### PR TITLE
Add end user specificity

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ To ensure your Pull Request is dealt with swiftly, please check the following (c
 - [ ] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. 
 - [ ] Comments and unused optional fields have been removed.
 - [ ] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
-- [ ] Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects.
+- [ ] Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects. The platforms should be for end users and not for development.
 - [ ] Any software project you are adding to the list is actively maintained.
 - [ ] Any software project you are adding was first released more than 4 months ago.
 - [ ] Any software project you are adding has working installation instructions.


### PR DESCRIPTION
Enhance the description for platforms to specify end user requirement. 

I wanted to add the instruction requirement however the checklist is already unwieldy and I didnt want to make it even more so. 

Could put this in the other instructions alongside https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/CONTRIBUTING.md#other-guidelines.