### PR TITLE
Remove Demo URL for JAuth

### DIFF
--- a/software/jauth.yml
+++ b/software/jauth.yml
@@ -8,7 +8,6 @@ platforms:
   - Go
 tags:
   - Proxy
-demo_url: https://j.ateam.undo.it/
 depends_3rdparty: true
 stargazers_count: 11
 updated_at: '2024-02-24'


### PR DESCRIPTION
 https://j.ateam.undo.it/ is responding with a 401 which is causing the deadlinks action to error, additionally the demo url is not listed anywhere in github for jauth. 

For that reason I propose removing the demo url.

Referencing #568, #570.