### PR TITLE
Remove Databag demo URL

### DIFF
--- a/software/databag.yml
+++ b/software/databag.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Communication - Custom Communication Systems
 source_code_url: https://github.com/balzack/databag
-demo_url: https://databag.coredb.org/#/create
 stargazers_count: 681
 updated_at: '2024-02-07'
 archived: false


### PR DESCRIPTION
- ref. #1
- `https://databag.coredb.org/#/create : HTTPSConnectionPool(host='databag.coredb.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1007)')))`
- not mentioned in the source code repository
