### PR TITLE
Update CloudBeaver URL

### DIFF
--- a/software/cloudbeaver.yml
+++ b/software/cloudbeaver.yml
@@ -1,5 +1,5 @@
 name: CloudBeaver
-website_url: https://cloudbeaver.io/
+website_url: https://dbeaver.com/
 description: Self-hosted management of databases, supports PostgreSQL, MySQL, SQLite and more. A web/hosted version of DBeaver.
 licenses:
   - Apache-2.0


### PR DESCRIPTION
- ref: #1
- All Links in the GitHub repo now point to the new website (dbeaver.com)
- `https://cloudbeaver.io/ : HTTP 404`
