### PR TITLE
Update VLC source code link

### DIFF
--- a/software/videolan-client-vlc.yml
+++ b/software/videolan-client-vlc.yml
@@ -8,7 +8,5 @@ platforms:
   - deb
 tags:
   - Media Streaming - Video Streaming
-source_code_url: https://github.com/videolan/vlc
-stargazers_count: 12820
-updated_at: '2023-03-24'
+source_code_url: https://code.videolan.org/videolan/vlc
 archived: false


### PR DESCRIPTION
- The github mirror does not appear to be up to date (last commit 5 days ago on the official git repository)
- ref. #1
- `ERROR:awesome_lint.py: VideoLAN Client (VLC): last updated -366 days, 1:32:18.644088 ago, older than 365 days`
- https://wiki.videolan.org/GetTheSource/#Development_Sources
