### PR TITLE
Update wikipedia link on URL shorteners

### DIFF
--- a/tags/url-shorteners.yml
+++ b/tags/url-shorteners.yml
@@ -1,2 +1,2 @@
 name: URL Shorteners
-description: '[URL shortening](https://en.wikipedia.org/wiki/URL_shortening) is the action of shortening a [URL](https://en.wikipedia.org/wiki/Uniform_Resource_Locator) to make it substantially shorter and still direct to the required page. Before hosting one, please see [shortcomings](https://en.wikipedia.org/wiki/URL_shortening#Shortcomings) of URL shorteners.'
+description: '[URL shortening](https://en.wikipedia.org/wiki/URL_shortening) is the action of shortening a [URL](https://en.wikipedia.org/wiki/Uniform_Resource_Locator) to make it substantially shorter and still direct to the required page. Before hosting one, please see [disadvantages](https://en.wikipedia.org/wiki/URL_shortening#Disadvantages) of URL shorteners.'


### PR DESCRIPTION
The heading was changed in revision on [11 September 2023](https://en.wikipedia.org/w/index.php?title=URL_shortening&oldid=1174944709) (without any update to its contents [since](https://en.wikipedia.org/w/index.php?diff=1214649442&oldid=1174944709&title=URL_shortening)). Additionally, update the text to reflect this change.
