### PR TITLE
Remove rgit demo URL

### DIFF
--- a/software/rgit.yml
+++ b/software/rgit.yml
@@ -9,7 +9,6 @@ platforms:
 tags:
   - Software Development - Project Management
 source_code_url: https://github.com/w4/rgit
-demo_url: https://git.inept.dev/
 stargazers_count: 67
 updated_at: '2024-02-03'
 archived: false


### PR DESCRIPTION
- timeout since at least 1 week
- `https://git.inept.dev/ : HTTPSConnectionPool(host='git.inept.dev', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f7cc14d09a0>: Failed to establish a new connection: [Errno 101] Network is unreachable'))`
- ref. #1
