### PR TITLE
Update Slimta website URL

### DIFF
--- a/software/slimta.yml
+++ b/software/slimta.yml
@@ -1,5 +1,5 @@
 name: Slimta
-website_url: https://www.slimta.org
+website_url: https://slimta.github.io/
 description: Mail Transfer Library built on Python.
 licenses:
   - MIT


### PR DESCRIPTION
- ref. #1
- https://github.com/slimta/python-slimta/commit/e983df05fafd457fbfd0bb8dce34c5357d6650e5
- `ERROR:url_check.py: [954/1327] https://www.slimta.org : HTTPSConnectionPool(host='www.slimta.org', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f58324f2fe0>: Failed to resolve 'www.slimta.org' ([Errno -3] Temporary failure in name resolution)"))`
