### PR TITLE
Update Demo URL of Ryot

### DIFF
--- a/software/ryot.yml
+++ b/software/ryot.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Personal Dashboards
-demo_url: https://ryot.fly.dev/auth/login?redirectTo=%2F
+demo_url: https://github.com/IgnisDa/ryot?tab=readme-ov-file#-demo
 stargazers_count: 1458
 updated_at: '2024-04-27'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://ryot.fly.dev/auth/login?redirectTo=%2F : HTTP 404`
- Move Demo URL to the GitHub Readme where the user can also find the credentials