### PR TITLE
Update phplist website

### DIFF
--- a/software/phplist.yml
+++ b/software/phplist.yml
@@ -1,5 +1,5 @@
 name: phpList
-website_url: https://phplist.org
+website_url: https://www.phplist.org
 description: Newsletter and email marketing with advanced management of subscribers, bounces, and plugins.
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://phplist.org : HTTPSConnectionPool(host='phplist.org', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7faaaa9047f0>: Failed to resolve 'phplist.org' ([Errno -5] No address associated with hostname)"))`
- All documentation links point to `www.phplist.org`