### PR TITLE
Remove dotclear website url

### DIFF
--- a/software/dotclear.yml
+++ b/software/dotclear.yml
@@ -1,5 +1,5 @@
 name: Dotclear
-website_url: https://dotclear.org/
+website_url: https://git.dotclear.org/dev/dotclear
 description: Take control over your blog.
 licenses:
   - GPL-2.0


### PR DESCRIPTION
- ref: #1
- `https://dotclear.org/ : HTTP 502`
- The website is down since at least [2 weeks](https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/8808058863/job/24176392792#step:4:2698)
- Maintainers have been already notified over a week ago [in there git repository](https://git.dotclear.org/dev/dotclear/issues/649)
