### PR TITLE
update opengist demo url

### DIFF
--- a/software/opengist.yml
+++ b/software/opengist.yml
@@ -10,7 +10,7 @@ platforms:
 tags:
   - Pastebins
 source_code_url: https://github.com/thomiceli/opengist
-demo_url: https://opengist.thomice.li
+demo_url: https://demo.opengist.io
 stargazers_count: 1414
 updated_at: '2024-05-12'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://opengist.thomice.li : HTTPSConnectionPool(host='opengist.thomice.li', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'opengist.thomice.li'. (_ssl.c:1007)")))`
- Demo URL moved to `https://demo.opengist.io`, old URL is currently still available
