### PR TITLE
doc: remove staticsitegenerators.net, update statigcgen.com link

### DIFF
--- a/.github/ISSUE_TEMPLATE/addition.md
+++ b/.github/ISSUE_TEMPLATE/addition.md
@@ -49,7 +49,7 @@ related_software_url: "https://my.awesome.softwar.e/apps"
 To ensure your issue is dealt with swiftly, please check the following (check the boxes `[x]`):
 - [ ] Submit one item per pull issue. This eases reviewing and speeds up inclusion.
 - [ ] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
-- [ ] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
+- [ ] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [jamstack/static site generators](https://jamstack.org/generators/), [dbdb.io](https://dbdb.io/browse).
 - [ ] Any software project you are adding to the list is actively maintained.
 - [ ] Any software project you are adding was first released more than 4 months ago.
 - [ ] Any software project you are adding has working installation instructions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Thanks for taking the time to suggest an addition to awesome-selfhosted!
 To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
 - [ ] Submit one item per pull request. This eases reviewing and speeds up inclusion.
 - [ ] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
-- [ ] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
+- [ ] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [jamstack/static site generators](https://jamstack.org/generators/), [dbdb.io](https://dbdb.io/browse).
 - [ ] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
 - [ ] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. 
 - [ ] Comments and unused optional fields have been removed.

--- a/tags/static-site-generators.yml
+++ b/tags/static-site-generators.yml
@@ -1,10 +1,8 @@
 name: Static Site Generators
 description: '[Static site generators](https://en.wikipedia.org/wiki/Web_template_system#Static_site_generators) generate full static HTML websites based on raw data, plain text files and a set of templates. '
 redirect:
-  - title: staticsitegenerators.net
-    url: https://staticsitegenerators.net
-  - title: staticgen.com
-    url: https://www.staticgen.com
+  - title: jamstack.org - Static Site Generators
+    url: https://jamstack.org/generators/
 related_tags:
   - Blogging Platforms
   - Photo and Video Galleries


### PR DESCRIPTION
- https://github.com/bevry/staticsitegenerators-list is unmaintained since 7 months, last update checks no longer working
- no activity in https://github.com/bevry/staticsitegenerators-list/issues
- staticgen.com now redirects to jacmstack.org/generators
