### PR TITLE
fix otobo

### DIFF
--- a/software/otobo.yml
+++ b/software/otobo.yml
@@ -1,5 +1,5 @@
 name: OTOBO
-website_url: https://otobo.de/en/
+website_url: https://otobo.io/en/
 description: Flexible web-based ticketing system used for Customer Service, Help Desk, IT Service Management.
 licenses:
   - GPL-3.0
@@ -9,7 +9,7 @@ platforms:
 tags:
   - Ticketing
 source_code_url: https://github.com/RotherOSS/otobo
-demo_url: https://otobo.de/en/open-source-ticketing-system/#demos
+demo_url: https://otobo.io/en/service-management-plattform/otobo-demo/
 stargazers_count: 237
 updated_at: '2024-06-14'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://otobo.de/en/open-source-ticketing-system/#demos : HTTP 404`
- Domain changed from `otobo.de` to `otobo.io`
- Demo URL changed from `https://otobo.de/en/open-source-ticketing-system/#demos` to `https://otobo.io/en/service-management-plattform/otobo-demo/`
