### PR TITLE
Remove stalwart-jmap website

### DIFF
--- a/software/stalwart-jmap.yml
+++ b/software/stalwart-jmap.yml
@@ -1,5 +1,5 @@
 name: Stalwart JMAP
-website_url: https://github.com/stalwartlabs/jmap-server
+website_url: https://stalw.art/docs/jmap/overview
 description: JMAP and IMAP server designed to be secure, fast, robust and scalable.
 licenses:
   - AGPL-3.0

--- a/software/stalwart-jmap.yml
+++ b/software/stalwart-jmap.yml
@@ -1,5 +1,5 @@
 name: Stalwart JMAP
-website_url: https://stalw.art/jmap
+website_url: https://github.com/stalwartlabs/jmap-server
 description: JMAP and IMAP server designed to be secure, fast, robust and scalable.
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://stalw.art/jmap : HTTP 404`
- There seems to be no good replacment
