### PR TITLE
Remove stalwart-smtp website

### DIFF
--- a/software/stalwart-smtp.yml
+++ b/software/stalwart-smtp.yml
@@ -1,5 +1,5 @@
 name: Stalwart SMTP
-website_url: https://github.com/stalwartlabs/smtp-server
+website_url: https://stalw.art/docs/smtp/overview
 description: Modern SMTP server designed with a focus on security, speed, and extensive configurability.
 licenses:
   - AGPL-3.0

--- a/software/stalwart-smtp.yml
+++ b/software/stalwart-smtp.yml
@@ -1,5 +1,5 @@
 name: Stalwart SMTP
-website_url: https://stalw.art/smtp
+website_url: https://github.com/stalwartlabs/smtp-server
 description: Modern SMTP server designed with a focus on security, speed, and extensive configurability.
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://stalw.art/smtp : HTTP 404`
- There seems to be no good replacement