### PR TITLE
Remove Seatsurfing demo

### DIFF
--- a/software/seatsurfing.yml
+++ b/software/seatsurfing.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Booking and Scheduling
 source_code_url: https://github.com/seatsurfing/backend
-demo_url: https://seatsurfing.app/get-started/
 stargazers_count: 100
 updated_at: '2024-07-01'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://seatsurfing.app/get-started/ : HTTP 404`
- The Demo moved to `https://seatsurfing.app/getting-started`, however for the demo you now need to register a account (which also includes registering and confirming an email address).