### PR TITLE
fix hitobito website

### DIFF
--- a/software/hitobito.yml
+++ b/software/hitobito.yml
@@ -1,5 +1,5 @@
 name: hitobito
-website_url: https://hitobito.com/en
+website_url: https://hitobito.com
 description: A web application to manage complex group hierarchies with members, events and a lot more.
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://hitobito.com/en : HTTP 404`
- Link to the domain without english suffix `https://hitobito.com`
