### PR TITLE
Remove Solidus demo

### DIFF
--- a/software/solidus.yml
+++ b/software/solidus.yml
@@ -9,7 +9,6 @@ platforms:
 tags:
   - E-commerce
 source_code_url: https://github.com/solidusio/solidus
-demo_url: https://demo.solidus.io/
 stargazers_count: 4936
 updated_at: '2024-06-24'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://demo.solidus.io/ : HTTPSConnectionPool(host='demo.solidus.io', port=443): Read timed out. (read timeout=10)`
- The Demo website is broken (without any css or js), [this has been reported already over a month ago](https://github.com/solidusio/solidus/issues/5777), but no one has fixed it yet.