### PR TITLE
Fix tryton

### DIFF
--- a/software/tryton.yml
+++ b/software/tryton.yml
@@ -7,5 +7,4 @@ platforms:
   - Python
 tags:
   - Resource Planning
-source_code_url: https://hg.tryton.org/
-demo_url: https://www.tryton.org/download.html
+source_code_url: https://foss.heptapod.net/tryton/tryton

--- a/software/tryton.yml
+++ b/software/tryton.yml
@@ -8,3 +8,4 @@ platforms:
 tags:
   - Resource Planning
 source_code_url: https://foss.heptapod.net/tryton/tryton
+demo_url: https://hg.tryton.org/demo


### PR DESCRIPTION
- ref: https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/1
- `https://hg.tryton.org/ : HTTP 404`
- The source code moved to `https://foss.heptapod.net/tryton/tryton` (see on the tryton.org, scroll down to the bottom, where the link is provided)
- The current demo links leads to the download of the software, not to an actual demo; replaced URL to `https://hg.tryton.org/demo`