### PR TITLE
Remove OvenMediaEngine website

### DIFF
--- a/software/ovenmediaengine.yml
+++ b/software/ovenmediaengine.yml
@@ -1,5 +1,5 @@
 name: OvenMediaEngine
-website_url: https://ovenmediaengine.com
+website_url: https://github.com/AirenSoft/OvenMediaEngine
 description: OvenMediaEngine is a selfhostable Open-Source Streaming Server with Sub-Second Latency.
 licenses:
   - GPL-3.0


### PR DESCRIPTION
- `ovenmediaengine.com` DNS name no longer resolvable
- replace with source code URL
- ref. #1
