### PR TITLE
Change EPrints repo to supported version

### DIFF
--- a/software/eprints.yml
+++ b/software/eprints.yml
@@ -7,7 +7,7 @@ platforms:
   - Perl
 tags:
   - Document Management - Institutional Repository and Digital Library Software
-source_code_url: https://github.com/eprints/eprints
+source_code_url: https://github.com/eprints/eprints3.4
 demo_url: http://tryme.demo.eprints-hosting.org/
 stargazers_count: 68
 updated_at: '2023-07-31'


### PR DESCRIPTION
- ref: #1
- `ERROR:awesome_lint.py: EPrints: last updated -367 days, 1:29:06.983800 ago, older than 365 days`
- The Repo is currently marked legacy and the new version is provided via eprints/eprints3.4