### PR TITLE
Fix tryton demo link

### DIFF
--- a/software/tryton.yml
+++ b/software/tryton.yml
@@ -8,4 +8,4 @@ platforms:
 tags:
   - Resource Planning
 source_code_url: https://foss.heptapod.net/tryton/tryton
-demo_url: https://hg.tryton.org/demo
+demo_url: https://www.tryton.org/demo


### PR DESCRIPTION
- ref: #1
- ` https://hg.tryton.org/demo : HTTP 404`
- Demo moved from sub-domain to main domain