### PR TITLE
tools: Update github actions/checkout to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       url: https://github.com/awesome-selfhosted/awesome-selfhosted
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - run: make install
@@ -48,7 +48,7 @@ jobs:
       url: https://github.com/awesome-selfhosted/awesome-selfhosted-html
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - run: make install

--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -17,6 +17,6 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make install
       - run: make url_check

--- a/.github/workflows/check-unmaintained-projects.yml
+++ b/.github/workflows/check-unmaintained-projects.yml
@@ -17,6 +17,6 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make install
       - run: make awesome_lint_strict

--- a/.github/workflows/daily-update-metadata.yml
+++ b/.github/workflows/daily-update-metadata.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make install
       - run: make update_metadata
       - name: commit and push changes

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
   syntax-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make install
       - run: make awesome_lint
       - run: make export_markdown


### PR DESCRIPTION
This is simply bumping actions/checkout to v4 rather then v3, courtesy of this deprecation notice: 
![image](https://github.com/user-attachments/assets/1dfc1c2e-8d82-40a5-abea-c0971022baac)

If there's any questions, suggestions, concerns, or comments, let me know!  