### PR TITLE
fix: coppermine-gallery has migrated

### DIFF
--- a/software/coppermine.yml
+++ b/software/coppermine.yml
@@ -1,5 +1,5 @@
 name: Coppermine
-website_url: https://coppermine-gallery.net/
+website_url: https://coppermine-gallery.com/
 description: Multilingual photo gallery that integrates with various bulletin boards. Includes upload approval and password protected albums.
 licenses:
   - GPL-3.0
@@ -8,7 +8,7 @@ platforms:
 tags:
   - Photo and Video Galleries
 source_code_url: https://github.com/coppermine-gallery/cpg1.6.x
-demo_url: https://coppermine-gallery.net/demo/cpg15x/
+demo_url: https://coppermine-gallery.com/demo/cpg15x/
 stargazers_count: 66
 updated_at: '2024-06-13'
 archived: false


### PR DESCRIPTION
The coppermine-gallery site has been migrated to https://coppermine-gallery.com/.

See also: https://github.com/coppermine-gallery/cpg1.6.x/issues/77#issuecomment-2371362007