### PR TITLE
remove lufi demo

### DIFF
--- a/software/lufi.yml
+++ b/software/lufi.yml
@@ -8,4 +8,3 @@ platforms:
 tags:
   - File Transfer - Single-click & Drag-n-drop Upload
 source_code_url: https://framagit.org/fiat-tux/hat-softwares/lufi/tree/master
-demo_url: https://demo.lufi.io


### PR DESCRIPTION
- ref. #1
- https://demo.lufi.io : HTTPSConnectionPool(host='demo.lufi.io', port=443): Max retries exceeded with url: / (Caused by NameResolutionError(<urllib3.connection.HTTPSConnection object at 0x7f20094fdd80>: Failed to resolve 'demo.lufi.io' ([Errno -2] Name or service not known)))
