### PR TITLE
update The Epube homepage/source code URL

### DIFF
--- a/software/the-epube.yml
+++ b/software/the-epube.yml
@@ -1,5 +1,5 @@
 name: The Epube
-website_url: https://tt-rss.org/the-epube
+website_url: https://gitlab.tt-rss.org/main/the-epube/-/wikis/home
 description: Self-hosted web EPUB reader using EPUB.js, Bootstrap, and Calibre.
 licenses:
   - GPL-3.0
@@ -7,4 +7,4 @@ platforms:
   - PHP
 tags:
   - Document Management - E-books
-source_code_url: https://git.tt-rss.org/fox/the-epube
+source_code_url: https://gitlab.tt-rss.org/main/the-epube


### PR DESCRIPTION
- ref. #1
- ERROR:url_check.py: [1067/1347] https://tt-rss.org/the-epube : HTTP 404
