### PR TITLE
Create cloud-gallery

### DIFF
--- a/software/cloud-gallery
+++ b/software/cloud-gallery
@@ -1,0 +1,13 @@
+name: "Cloud Gallery"
+website_url: "https://play.google.com/store/apps/details?id=com.canopas.cloud_gallery"
+source_code_url: "https://github.com/canopas/cloud-gallery"
+description: "Cloud Gallery is a Flutter application designed to manage user media seamlessly across multiple cloud providers like Google Drive, Dropbox, while also allowing users to access and organize their local media."
+licenses:
+  - Apache-2.0
+platforms:
+  - Firebase
+  - Docker
+tags:
+  - Photo and Video Galleries
+depends_3rdparty: false
+demo_url: "https://apps.apple.com/in/app/cloud-gallery/id6480052005?platform=iphone"


### PR DESCRIPTION
Add cloud gallery in Photo and Video Galleries.

<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->

Thanks for taking the time to suggest an addition to awesome-selfhosted! 

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. 
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged ~1 week after approval, to allow for further comments if needed.
