### PR TITLE
Update Synapse docs link to point to the new maintainer Element's site

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1395,7 +1395,6 @@ Commits|Author
      1	ghaseminya <ghaseminya@gmail.com>
      1	gloriafolaron <55953099+gloriafolaron@users.noreply.github.com>
      1	golangci <35628013+golangci@users.noreply.github.com>
-     1	hy6lJuJa <125956836+hy6lJuJa@users.noreply.github.com>
      1	ice-92 <ice-92@users.noreply.github.com>
      1	ifshee <85419413+ifshee@users.noreply.github.com>
      1	ilsi <ilsi@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1395,6 +1395,7 @@ Commits|Author
      1	ghaseminya <ghaseminya@gmail.com>
      1	gloriafolaron <55953099+gloriafolaron@users.noreply.github.com>
      1	golangci <35628013+golangci@users.noreply.github.com>
+     1	hy6lJuJa <125956836+hy6lJuJa@users.noreply.github.com>
      1	ice-92 <ice-92@users.noreply.github.com>
      1	ifshee <85419413+ifshee@users.noreply.github.com>
      1	ilsi <ilsi@users.noreply.github.com>

--- a/software/synapse.yml
+++ b/software/synapse.yml
@@ -1,5 +1,5 @@
 name: Synapse
-website_url: https://matrix-org.github.io/synapse/latest/
+website_url: https://element-hq.github.io/synapse/latest/index.html
 description: Server for [Matrix](https://matrix.org/), an open standard for decentralized persistent communication.
 licenses:
   - Apache-2.0


### PR DESCRIPTION
<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->

Thanks for taking the time to suggest an addition to awesome-selfhosted! 

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. 
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` are the main **server-side** requirements for the software. Don't include frameworks or specific dialects.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged ~1 week after approval, to allow for further comments if needed.
