### PR TITLE
remove demo from payload cms

### DIFF
--- a/software/payload-cms.yml
+++ b/software/payload-cms.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Content Management Systems (CMS)
 source_code_url: https://github.com/payloadcms/payload
-demo_url: https://demo.payloadcms.com
 stargazers_count: 27810
 updated_at: '2024-11-22'
 archived: false


### PR DESCRIPTION
- ref: #1
- ref: https://github.com/payloadcms/payload/commit/304ecd29acad105cef54af8facde110d0c33bc56
- `https://demo.payloadcms.com : HTTPSConnectionPool(host='demo.payloadcms.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1007)')))`