### PR TITLE
remove website of eda

### DIFF
--- a/software/eda.yml
+++ b/software/eda.yml
@@ -1,5 +1,5 @@
 name: EDA
-website_url: https://eda.jortilles.com/en/jortilles-english/
+website_url: https://github.com/jortilles/EDA
 description: Web application for data analysis and visualization.
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1
- ` https://eda.jortilles.com/en/jortilles-english/ : HTTP 404`
- Website seems to have been removed, while the project is still active their is no link to the website 