### PR TITLE
remove website from rygel

### DIFF
--- a/software/rygel.yml
+++ b/software/rygel.yml
@@ -1,5 +1,5 @@
 name: Rygel
-website_url: https://wiki.gnome.org/action/show/Projects/Rygel
+website_url: https://gitlab.gnome.org/GNOME/rygel/
 description: Rygel is a UPnP AV MediaServer that allows you to easily share audio, video, and pictures. Media player software may use Rygel to become a MediaRenderer that may be controlled remotely by a UPnP or DLNA Controller.
 licenses:
   - GPL-3.0

--- a/software/rygel.yml
+++ b/software/rygel.yml
@@ -1,5 +1,5 @@
 name: Rygel
-website_url: https://gitlab.gnome.org/GNOME/rygel/
+website_url: https://gnome.pages.gitlab.gnome.org/rygel/
 description: Rygel is a UPnP AV MediaServer that allows you to easily share audio, video, and pictures. Media player software may use Rygel to become a MediaRenderer that may be controlled remotely by a UPnP or DLNA Controller.
 licenses:
   - GPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://wiki.gnome.org/action/show/Projects/Rygel : HTTP 403`
- When visiting the website you recieve access denied
- The repo does not point to the website