### PR TITLE
add e-book tag to audiobookshelf

### DIFF
--- a/software/audiobookshelf.yml
+++ b/software/audiobookshelf.yml
@@ -9,6 +9,7 @@ platforms:
   - Nodejs
 tags:
   - Media Streaming - Audio Streaming
+  - Document Management - E-books
 source_code_url: https://github.com/advplyr/audiobookshelf
 related_software_url: https://github.com/advplyr/audiobookshelf-app
 stargazers_count: 7001


### PR DESCRIPTION
- Closes #1003
- Mentions support for e-books in the [Documentation](https://www.audiobookshelf.org/docs/)
- Visiting their [Demo](https://audiobooks.dev) (with credentials `demo`), you can see they have their own area for e-books
