### PR TITLE
Update Kresus' license

### DIFF
--- a/software/kresus.yml
+++ b/software/kresus.yml
@@ -2,7 +2,7 @@ name: Kresus
 website_url: https://kresus.org/
 description: Open source personal finance manager.
 licenses:
-  - MIT
+  - AGPL-3.0
 platforms:
   - Nodejs
   - Docker
@@ -11,5 +11,5 @@ tags:
 source_code_url: https://github.com/kresusapp/kresus
 demo_url: https://kresus.org/en/demo.html
 stargazers_count: 304
-updated_at: '2024-12-12'
+updated_at: '2024-12-14'
 archived: false

--- a/software/kresus.yml
+++ b/software/kresus.yml
@@ -11,5 +11,5 @@ tags:
 source_code_url: https://github.com/kresusapp/kresus
 demo_url: https://kresus.org/en/demo.html
 stargazers_count: 304
-updated_at: '2024-12-14'
+updated_at: '2024-12-12'
 archived: false


### PR DESCRIPTION
It's been upgraded from MIT to AGPLv3.0 recently. More details in the French blog post: https://kresus.org/blog/mit-vers-agpl.html