### PR TITLE
Update cal.com.yml license

### DIFF
--- a/software/cal.com.yml
+++ b/software/cal.com.yml
@@ -2,7 +2,7 @@ name: Cal.com
 website_url: https://cal.com/
 description: The open-source online appointment scheduling system.
 licenses:
-  - AGPLv3
+  - AGPL-3.0
 platforms:
   - Nodejs
 tags:

--- a/software/cal.com.yml
+++ b/software/cal.com.yml
@@ -2,7 +2,7 @@ name: Cal.com
 website_url: https://cal.com/
 description: The open-source online appointment scheduling system.
 licenses:
-  - MIT
+  - AGPLv3
 platforms:
   - Nodejs
 tags:


### PR DESCRIPTION
License for cal.com [was changed from MIT to AGPLv3 back in 2021](https://github.com/calcom/cal.com/commit/5ad825544a7787f58db7c7e9e12da49c6a6a0ad0).