### PR TITLE
Update the addition issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/addition.md
+++ b/.github/ISSUE_TEMPLATE/addition.md
@@ -2,7 +2,7 @@
 name: Addition
 about: Add new software to the list.
 title: Add SOFTWARE_NAME
-labels: addition
+labels: addition, reviewers wanted
 assignees: ''
 
 ---
@@ -47,7 +47,7 @@ related_software_url: "https://my.awesome.softwar.e/apps"
 ```
 
 To ensure your issue is dealt with swiftly, please check the following (check the boxes `[x]`):
-- [ ] Submit one item per pull issue. This eases reviewing and speeds up inclusion.
+- [ ] Submit one item per issue. This eases reviewing and speeds up inclusion.
 - [ ] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
 - [ ] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
 - [ ] Any software project you are adding to the list is actively maintained.


### PR DESCRIPTION
## Summary
Changes the issue template to by default add the "reviewers wanted" label.
Also fixed an extraneous word in the template.

I have tested this: https://github.com/TheGiraffe3/awesome-selfhosted-data/issues/1
Reviewers: feel free to open a new issue on my repository to confirm for yourself.