### PR TITLE
Update anycable source code URL

### DIFF
--- a/software/anycable.yml
+++ b/software/anycable.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Communication - Custom Communication Systems
-source_code_url: https://github.com/anycable/anycable-go
+source_code_url: https://github.com/anycable/anycable
 demo_url: https://demo.anycable.io
 stargazers_count: 383
 updated_at: '2024-12-28'


### PR DESCRIPTION
- ERROR:awesome_lint.py: AnyCable: the project is archived
- This repository has been archived by the owner on Dec 28, 2024. It is now read-only. 
- This project has moved to anycable/anycable. Please, follow it for further updates!
