### PR TITLE
Remove Github stats from Inboxen

### DIFF
--- a/software/inboxen.yml
+++ b/software/inboxen.yml
@@ -8,5 +8,3 @@ platforms:
 tags:
   - Communication - Email - Complete Solutions
 source_code_url: https://codeberg.org/Inboxen/Inboxen
-stargazers_count: 262
-updated_at: '2023-12-16'


### PR DESCRIPTION
I think Inboxen used to be a github repo however the source code is now codeberg but it kept the GH stats. This broke the unmaintained projects action:

`ERROR:awesome_lint.py: Inboxen: last updated -379 days, 1:27:57.659409 ago, older than 365 days`