### PR TITLE
Add Elixir platform to Cannery app

### DIFF
--- a/software/cannery.yml
+++ b/software/cannery.yml
@@ -6,5 +6,6 @@ licenses:
   - AGPL-3.0
 platforms:
   - Docker
+  - Elixir
 tags:
   - Inventory Management


### PR DESCRIPTION
I forgot to add Elixir into the list of platforms for Cannery. While there aren't any host-specific installation instructions in the readme, the app should be straightforward to host like any Phoenix application.

Thank you!