### PR TITLE
fix: correct license and platforms for Manticore Search

### DIFF
--- a/software/manticore-search.yml
+++ b/software/manticore-search.yml
@@ -2,11 +2,12 @@ name: Manticore Search
 website_url: https://github.com/manticoresoftware/manticoresearch/
 description: Full-text search and data analytics, with fast response time for small, medium and big data (alternative to Elasticsearch).
 licenses:
-  - GPL-2.0
+  - GPL-3.0
 platforms:
   - Docker
   - deb
   - C++
+  - K8S
 tags:
   - Search Engines
 source_code_url: https://github.com/manticoresoftware/manticoresearch/


### PR DESCRIPTION
Manticore is now GPL-v3 licensed (switched from GPL-v2 a while ago). There's also a Helm Chart to run it in K8S - https://github.com/manticoresoftware/manticoresearch-helm

<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->