### PR TITLE
header: clearly mark the markdown version as legacy/deprecated

### DIFF
--- a/.hecat/export-markdown.yml
+++ b/.hecat/export-markdown.yml
@@ -5,7 +5,7 @@ steps:
       source_directory: ./
       output_directory: awesome-selfhosted
       output_file: README.md
-      markdown_header: markdown/header.md
+      markdown_header: markdown/header-singlepage.md
       markdown_footer: markdown/footer.md
       back_to_top_url: '#awesome-selfhosted'
       exclude_licenses:

--- a/markdown/header-singlepage.md
+++ b/markdown/header-singlepage.md
@@ -6,4 +6,7 @@ Self-hosting is the practice of hosting and managing applications on your own se
 
 This is a list of [Free](https://en.wikipedia.org/wiki/Free_software) Software [network services](https://en.wikipedia.org/wiki/Network_service) and [web applications](https://en.wikipedia.org/wiki/Web_application) which can be hosted on your own server(s). Non-Free software is listed on the [Non-Free](https://github.com/awesome-selfhosted/awesome-selfhosted/blob/master/non-free.md) page.
 
+> [!IMPORTANT]
+> **Please use [awesome-selfhosted.net](https://awesome-selfhosted.net/) instead.** The legacy, single-page markdown list format is deprecated.
+
 See [Contributing](#contributing).


### PR DESCRIPTION
I saw on several occasions people still linking to the old, single flat markdown file version of the list. This does not appear to be out of preference for the old format, but rather not knowing about the "new" (1.5 year old already) website.

This PR adds a rather obvious banner at the top of https://github.com/awesome-selfhosted/awesome-selfhosted (not on the website)

![image](https://github.com/user-attachments/assets/c9946081-347e-4adb-a488-76d8e66460a8)
