### PR TITLE
Update Actual source code URL

### DIFF
--- a/software/actual.yml
+++ b/software/actual.yml
@@ -8,7 +8,6 @@ platforms:
   - Docker
 tags:
   - Money, Budgeting & Management
-source_code_url: https://github.com/actualbudget/actual-server
+source_code_url: https://github.com/actualbudget/actual
 stargazers_count: 3411
 updated_at: '2025-02-09'
-archived: true


### PR DESCRIPTION
> This repository has been archived by the owner on Feb 10, 2025. It is now read-only.
> This repository will be merged into [actualbudget/actual](https://github.com/actualbudget/actual/tree/master/packages/sync-server) in February 2025 and placed in a readonly state