### PR TITLE
update website of pimcore

### DIFF
--- a/software/pimcore.yml
+++ b/software/pimcore.yml
@@ -1,5 +1,5 @@
 name: Pimcore
-website_url: https://www.pimcore.org/
+website_url: http://www.pimcore.com/
 description: Multi-Channel Experience and Engagement Management Platform.
 licenses:
   - GPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://www.pimcore.org/ : HTTPSConnectionPool(host='www.pimcore.org', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7facaf9a02f0>: Failed to resolve 'www.pimcore.org' ([Errno -5] No address associated with hostname)"))`
- Domain was moved from .org to .com