### PR TITLE
remove WikiDocs demo

### DIFF
--- a/software/wikidocs.yml
+++ b/software/wikidocs.yml
@@ -9,7 +9,6 @@ platforms:
   - Docker
 tags:
   - Wikis
-demo_url: https://demo.wikidocs.it
 stargazers_count: 390
 updated_at: '2025-02-28'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://demo.wikidocs.it : HTTPSConnectionPool(host='demo.wikidocs.it', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1000)')))`
- SSL Error exists now for at least one month (https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/13230224825/job/36926286512)