### PR TITLE
remove demo from enigma-12-bbs

### DIFF
--- a/software/enigma-12-bbs.yml
+++ b/software/enigma-12-bbs.yml
@@ -10,7 +10,6 @@ platforms:
 tags:
   - Communication - Social Networks and Forums
 source_code_url: https://github.com/NuSkooler/enigma-bbs
-demo_url: https://l33t.codes/xibalba-bbs/
 stargazers_count: 561
 updated_at: '2025-02-23'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://l33t.codes/xibalba-bbs/ : HTTPSConnectionPool(host='l33t.codes', port=443): Max retries exceeded with url: /xibalba-bbs/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7facaf96e2d0>: Failed to establish a new connection: [Errno 111] Connection refused'))`
- Neither website nor repo point to any demo