### PR TITLE
remove demo from mathesar

### DIFF
--- a/software/mathesar.yml
+++ b/software/mathesar.yml
@@ -9,7 +9,6 @@ platforms:
 tags:
   - Database Management
 source_code_url: https://github.com/centerofci/mathesar
-demo_url: https://demo.mathesar.org/
 stargazers_count: 3983
 updated_at: '2025-03-04'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://demo.mathesar.org/ : HTTPSConnectionPool(host='demo.mathesar.org', port=443): Max retries exceeded with url: / (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7facaf9a1700>, 'Connection to demo.mathesar.org timed out. (connect timeout=10)'))`
- Demo seems to be removed, no mentions of it on website or repo