### PR TITLE
fix dspace website url

### DIFF
--- a/software/dspace.yml
+++ b/software/dspace.yml
@@ -1,5 +1,5 @@
 name: DSpace
-website_url: https://duraspace.org/dspace/
+website_url: http://www.dspace.org/
 description: Turnkey repository application providing durable access to digital resources.
 licenses:
   - BSD-3-Clause


### PR DESCRIPTION
- ref: #1
- `https://duraspace.org/dspace/ : HTTPSConnectionPool(host='duraspace.org', port=443): Max retries exceeded with url: /dspace/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7facafcdd340>: Failed to establish a new connection: [Errno 111] Connection refused'))`
- README points to new url