### PR TITLE
Update MyFin after soft rebrand

### DIFF
--- a/software/myfin-budget.yml
+++ b/software/myfin-budget.yml
@@ -1,15 +1,16 @@
-name: MyFin
-website_url: https://github.com/afaneca/myfin
+name: MyFin Budget
+website_url: https://myfinbudget.com
 source_code_url: https://github.com/afaneca/myfin
 description: Personal finances platform (web + REST API + Android) that'll help you budget, keep track of your income/spending and forecast your financial future.
 licenses:
   - AGPL-3.0
 platforms:
   - Nodejs
+  - Docker
 tags:
   - Money, Budgeting & Management
 demo_url: https://github.com/afaneca/myfin?tab=readme-ov-file#demo-account---try-it-for-yourself
-related_software_url: https://github.com/afaneca/myfin-android
+related_software_url: https://github.com/afaneca/myfin-api
 stargazers_count: 134
 updated_at: '2025-02-22'
 archived: false


### PR DESCRIPTION
Resubmission of #1150, with cleaner git history.
<hr>
MyFin is now known as "MyFin Budget" and has added Docker integration.

In this PR, I:
- Renamed to "MyFin Budget" (including the file name)
- Added "Docker" platform
- Changed the related software link from the android frontend to the api repository