### PR TITLE
Fix source code url for apache http server

### DIFF
--- a/software/apache-http-server.yml
+++ b/software/apache-http-server.yml
@@ -1,6 +1,6 @@
 name: "Apache HTTP Server"
 website_url: "https://httpd.apache.org/"
-source_code_url: "https://github.com/apache/httpd"
+source_code_url: "https://svn.apache.org/repos/asf/httpd/httpd/trunk/"
 description: "Secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards."
 licenses:
   - Apache-2.0

--- a/software/apache-http-server.yml
+++ b/software/apache-http-server.yml
@@ -1,6 +1,6 @@
 name: "Apache HTTP Server"
 website_url: "https://httpd.apache.org/"
-source_code_url: "https://svn.apache.org/viewvc/httpd/httpd/branches/2.4.x/"
+source_code_url: "https://github.com/apache/httpd"
 description: "Secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards."
 licenses:
   - Apache-2.0


### PR DESCRIPTION
This is for simply adjusting apache's HTTP server source code to the mirror referenced in #1203 thus avoiding having to outright delete the server entirely from the list. I'm open to feedback from collaborators if this isn't the clear cut solution 