### PR TITLE
fix build error

### DIFF
--- a/software/standard-notes.yml
+++ b/software/standard-notes.yml
@@ -9,7 +9,6 @@ tags:
   - Note-taking & Editors
 source_code_url: https://github.com/standardnotes/app
 demo_url: https://app.standardnotes.com/
-demo_url: https://app.standardnotes.com/
 stargazers_count: 5624
 updated_at: '2025-02-03'
 archived: false


### PR DESCRIPTION
Removes duplicated demo url from Standard Notes introduced in #1201 