### PR TITLE
fix Media Management tag syntax

### DIFF
--- a/tags/media-streaming.yml
+++ b/tags/media-streaming.yml
@@ -12,5 +12,5 @@ redirect:
     url: '#media-streaming---multimedia-streaming'
   - title: Media streaming - Video Streaming
     url: '#media-streaming---video-streaming'
-  related_tags:
-  - Media Management
+  - title: Media Management
+    url: '#media-management'


### PR DESCRIPTION
- indentation issue on related_tags
- use redirect instead of related_tags, more consistent
