### PR TITLE
Remove EasyRSS as related software

### DIFF
--- a/software/freshrss.yml
+++ b/software/freshrss.yml
@@ -10,7 +10,6 @@ tags:
   - Feed Readers
 source_code_url: https://github.com/FreshRSS/FreshRSS
 demo_url: https://demo.freshrss.org/i/
-related_software_url: https://github.com/Alkarex/EasyRSS
 stargazers_count: 11326
 updated_at: '2025-04-18'
 archived: false


### PR DESCRIPTION
<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->

Thanks for taking the time to suggest an addition to awesome-selfhosted! 

[EasyRSS](https://github.com/Alkarex/EasyRSS) has been archived as off 28/11/24