### PR TITLE
Update OpenBudgeteer license

### DIFF
--- a/software/openbudgeteer.yml
+++ b/software/openbudgeteer.yml
@@ -2,7 +2,7 @@ name: OpenBudgeteer
 website_url: https://github.com/TheAxelander/OpenBudgeteer
 description: A budgeting app based on the Bucket Budgeting Principle.
 licenses:
-  - MIT
+  - AGPL-3.0
 platforms:
   - Docker
   - C#


### PR DESCRIPTION
With Update 1.10 the license of OpenBudgeteer has been changed to AGPL-3.0
