### PR TITLE
Move Kiwix Tag

### DIFF
--- a/software/kiwix-serve.yml
+++ b/software/kiwix-serve.yml
@@ -6,7 +6,7 @@ licenses:
 platforms:
   - C++
 tags:
-  - Note-taking & Editors
+  - Document Management - E-books
 source_code_url: https://github.com/kiwix/kiwix-tools
 stargazers_count: 565
 updated_at: '2025-04-20'


### PR DESCRIPTION
Closes #1347
Move Kiwix tag from Notetaking editiors to Ebook management.