### PR TITLE
fix: correct website_url for chibisafe

### DIFF
--- a/software/chibisafe.yml
+++ b/software/chibisafe.yml
@@ -1,5 +1,5 @@
 name: Chibisafe
-website_url: https://chibisafe.moe
+website_url: https://chibisafe.app
 source_code_url: https://github.com/chibisafe/chibisafe
 description: File uploader service that aims to to be easy to use and set up. It accepts files, photos, documents, anything you imagine and gives you back a shareable link for you to send to others.
 licenses:


### PR DESCRIPTION
Changing `chibisafe.moe` to `chibisafe.app`.

This is also the link listed in the GitHub repository:
- https://github.com/chibisafe/chibisafe

---

Further context:

![discord-context](https://github.com/user-attachments/assets/19edc99a-1c61-4c8c-ba28-117fa775014d)

- Discord join link is available at https://chibisafe.app
- Discord message link: https://discord.com/channels/361432183010754562/361432183560470539/1372787995509522442
