### PR TITLE
Remove Weblate demo link

### DIFF
--- a/software/weblate.yml
+++ b/software/weblate.yml
@@ -10,7 +10,6 @@ platforms:
 tags:
   - Software Development - Localization
 source_code_url: https://github.com/WeblateOrg/weblate
-demo_url: https://demo.weblate.org
 stargazers_count: 5088
 updated_at: '2025-05-18'
 archived: false


### PR DESCRIPTION
https://demo.weblate.org redirects to the pricing page
