### PR TITLE
Update Liwan License

### DIFF
--- a/software/liwan.yml
+++ b/software/liwan.yml
@@ -2,7 +2,7 @@ name: Liwan
 website_url: https://liwan.dev/
 description: Privacy-first web analytics.
 licenses:
-  - AGPL-3.0
+  - Apache-2.0
 platforms:
   - Rust
   - Docker


### PR DESCRIPTION
All versions of Liwan have been relicensed under the Apache-2.0, see https://github.com/explodingcamera/liwan/blob/main/LICENSE.md