### PR TITLE
Update WeddingShare Urls to correct domain

### DIFF
--- a/software/weddingshare.yml
+++ b/software/weddingshare.yml
@@ -1,6 +1,6 @@
 name: "WeddingShare"
-website_url: "https://docs.wedding-share.com/"
-demo_url: "https://demo.wedding-share.com/"
+website_url: "https://docs.wedding-share.org/"
+demo_url: "https://demo.wedding-share.org/"
 source_code_url: "https://github.com/Cirx08/WeddingShare"
 description: "Event photo sharing platform and gallery with slideshow that allows guests to view and share memories via a QR code."
 licenses:


### PR DESCRIPTION
Update WeddingShare domain from incorrect `.com` to `.org` for both the demo and site Urls.