### PR TITLE
General clean up of projects beginning with R

### DIFF
--- a/software/radarr.yml
+++ b/software/radarr.yml
@@ -1,6 +1,6 @@
 name: Radarr
 website_url: https://radarr.video/
-description: Radarr is an independent fork of Sonarr reworked for automatically downloading movies via Usenet and BitTorrent, à la Couchpotato.
+description: Automatically download movies via Usenet and BitTorrent, à la Couchpotato.
 licenses:
   - GPL-3.0
 platforms:

--- a/software/raneto.yml
+++ b/software/raneto.yml
@@ -1,6 +1,6 @@
 name: Raneto
 website_url: https://raneto.com/
-description: Raneto is an open source Knowledgebase platform that uses static Markdown files to power your Knowledgebase.
+description: Knowledgebase platform that uses static Markdown files to power your knowledgebase.
 licenses:
   - MIT
 platforms:

--- a/software/rapidbay.yml
+++ b/software/rapidbay.yml
@@ -1,6 +1,6 @@
 name: Rapidbay
 website_url: https://github.com/hauxir/rapidbay/
-description: Self-hosted torrent videostreaming service/torrent client that allows searching and playing videos from torrents in the browser or from a Chromecast/AppleTV/Smart TV.
+description: Torrent videostreaming service/torrent client that allows searching and playing videos from torrents in the browser or from a Chromecast/AppleTV/Smart TV.
 licenses:
   - MIT
 platforms:

--- a/software/reactive-resume.yml
+++ b/software/reactive-resume.yml
@@ -1,6 +1,6 @@
 name: Reactive Resume
 website_url: https://rxresu.me/
-description: A one-of-a-kind resume builder that keeps your privacy in mind. Completely secure, customizable, portable, open-source and free forever.
+description: One-of-a-kind resume builder that keeps your privacy in mind. Completely secure, customizable, portable, open-source and free forever.
 licenses:
   - MIT
 platforms:

--- a/software/readeck.yml
+++ b/software/readeck.yml
@@ -1,7 +1,7 @@
 name: "Readeck"
 website_url: "https://readeck.org/en/"
 source_code_url: "https://codeberg.org/readeck/readeck"
-description: "Readeck is a simple web application that lets you save the precious readable content of web pages you like and want to keep forever. See it as a bookmark manager and a read later tool."
+description: "Save the precious readable content of web pages you like and want to keep forever. See it as a bookmark manager and a read later tool."
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/reader.yml
+++ b/software/reader.yml
@@ -1,6 +1,6 @@
 name: reader
 website_url: https://github.com/lemon24/reader
-description: A Python feed reader web app and library (so you can use it to build your own), with only standard library and pure-Python dependencies.
+description: Feed reader web app and library (so you can use it to build your own), with only standard library and pure-Python dependencies.
 licenses:
   - BSD-3-Clause
 platforms:

--- a/software/readflow.yml
+++ b/software/readflow.yml
@@ -1,6 +1,6 @@
 name: Readflow
 website_url: https://readflow.app
-description: 'Lightweight news reader with modern interface and features: full-text search, automatic categorization, archiving, offline support, notifications...'
+description: 'Lightweight news reader with modern interface and features: full-text search, automatic categorization, archiving, offline support, notifications.'
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/readflow.yml
+++ b/software/readflow.yml
@@ -2,7 +2,7 @@ name: Readflow
 website_url: https://readflow.app
 description: 'Lightweight news reader with modern interface and features: full-text search, automatic categorization, archiving, offline support, notifications...'
 licenses:
-  - MIT
+  - AGPL-3.0
 platforms:
   - Go
   - Docker

--- a/software/recipya.yml
+++ b/software/recipya.yml
@@ -1,7 +1,7 @@
 name: Recipya
 website_url: https://recipes.musicavis.ca
 source_code_url: https://github.com/reaper47/recipya
-description: A clean, simple and powerful recipe manager your whole family will enjoy.
+description: Clean, simple and powerful recipe manager your whole family will enjoy.
 licenses:
   - GPL-3.0
 platforms:

--- a/software/red-eclipse-2.yml
+++ b/software/red-eclipse-2.yml
@@ -1,6 +1,6 @@
 name: Red Eclipse 2
 website_url: https://redeclipse.net
-description: A FOSS Arena First-Person Shooter Similar to Unreal Tournament.
+description: Arena first-person shooter similar to Unreal Tournament.
 licenses:
   - Zlib
   - MIT

--- a/software/redaxo.yml
+++ b/software/redaxo.yml
@@ -1,6 +1,6 @@
 name: REDAXO
 website_url: https://www.redaxo.org
-description: Simple, flexible and useful content management system (documentation only available in German).
+description: Simple, flexible and useful content management system (documentation in German).
 licenses:
   - MIT
 platforms:

--- a/software/redmine.yml
+++ b/software/redmine.yml
@@ -1,6 +1,6 @@
 name: Redmine
 website_url: https://www.redmine.org/
-description: Redmine is a flexible project management web application.
+description: Flexible project management web application.
 licenses:
   - GPL-2.0
 platforms:

--- a/software/rei3.yml
+++ b/software/rei3.yml
@@ -1,6 +1,6 @@
 name: REI3
 website_url: https://rei3.de/home_en/
-description: Open source, expandable Business Management Software. Manage tasks, time, assets and much more.
+description: Manage tasks, time, assets and much more within your business.
 licenses:
   - MIT
 platforms:

--- a/software/relate.yml
+++ b/software/relate.yml
@@ -1,6 +1,6 @@
 name: RELATE
 website_url: https://documen.tician.de/relate/
-description: 'RELATE is a web-based courseware package, includes features such as: flexible rules, statistics, multi-course support, class calendar.'
+description: 'Courseware package that includes features such as: flexible rules, statistics, multi-course support, class calendar.'
 licenses:
   - MIT
 platforms:

--- a/software/remark42.yml
+++ b/software/remark42.yml
@@ -1,6 +1,6 @@
 name: remark42
 website_url: https://remark42.com/
-description: A lightweight and simple comment engine, which doesn't spy on users. It can be embedded into blogs, articles or any other place where readers add comments.
+description: Lightweight and simple comment engine, which doesn't spy on users. It can be embedded into blogs, articles or any other place where readers add comments.
 licenses:
   - MIT
 platforms:

--- a/software/remotely.yml
+++ b/software/remotely.yml
@@ -1,6 +1,6 @@
 name: Remotely
 website_url: https://github.com/immense/Remotely
-description: A remote desktop control and remote scripting solution, enterprise level remote support solution with admin web interface and remote control via browser.
+description: Remote desktop control and remote scripting solution, enterprise level remote support solution with admin web interface and remote control via browser.
 licenses:
   - GPL-3.0
 platforms:

--- a/software/remoteutilities.yml
+++ b/software/remoteutilities.yml
@@ -1,6 +1,6 @@
 name: RemoteUtilities
 website_url: https://www.remoteutilities.com/
-description: Remote Utilities is self-hosted remote support software for LAN administration and remote support over the Internet.
+description: Remote support software for LAN administration and remote support over the Internet.
 licenses:
   - ⊘ Proprietary
 platforms:

--- a/software/request-tracker.yml
+++ b/software/request-tracker.yml
@@ -1,6 +1,6 @@
 name: Request Tracker
 website_url: https://www.bestpractical.com/rt/
-description: An enterprise-grade issue tracking system.
+description: Enterprise-grade issue tracking system.
 licenses:
   - GPL-2.0
 platforms:

--- a/software/resourcespace.yml
+++ b/software/resourcespace.yml
@@ -1,6 +1,6 @@
 name: ResourceSpace
 website_url: https://www.resourcespace.com
-description: ResourceSpace open source digital asset management software is the simple, fast, and free way to organise your digital assets.
+description: Simple, fast, and free way to organise your digital assets.
 licenses:
   - BSD-4-Clause
 platforms:

--- a/software/restreamer.yml
+++ b/software/restreamer.yml
@@ -1,6 +1,6 @@
 name: Restreamer
 website_url: https://datarhei.github.io/restreamer/
-description: Restreamer allows you to do h.264 real-time video streaming on your website without a streaming provider.
+description: Access h.264 real-time video streaming on your website without a streaming provider.
 licenses:
   - Apache-2.0
 platforms:

--- a/software/retrospring.yml
+++ b/software/retrospring.yml
@@ -1,6 +1,6 @@
 name: Retrospring
 website_url: https://github.com/retrospring/retrospring
-description: A free, open-source social network following the Q/A (question and answer) principle of sites like Formspring, ask.fm or CuriousCat.
+description: Social network following the Q/A (question and answer) principle of sites like Formspring, ask.fm or CuriousCat.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/revealjs.yml
+++ b/software/revealjs.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Miscellaneous
 source_code_url: https://github.com/hakimel/reveal.js
-demo_url: https://revealjs.com/
 stargazers_count: 68925
 updated_at: '2025-04-28'
 archived: false

--- a/software/revive-adserver.yml
+++ b/software/revive-adserver.yml
@@ -1,6 +1,6 @@
 name: Revive Adserver
 website_url: https://www.revive-adserver.com/
-description: World's most popular free, open source ad serving system. Formerly known as OpenX Adserver and phpAdsNew.
+description: Ad serving system. Formerly known as OpenX Adserver and phpAdsNew.
 licenses:
   - GPL-2.0
 platforms:

--- a/software/rgit.yml
+++ b/software/rgit.yml
@@ -1,6 +1,6 @@
 name: rgit
 website_url: https://github.com/w4/rgit
-description: An ultra-fast & lightweight cgit clone.
+description: Ultra-fast & lightweight cgit clone.
 licenses:
   - WTFPL
 platforms:

--- a/software/rhodecode.yml
+++ b/software/rhodecode.yml
@@ -1,6 +1,6 @@
 name: RhodeCode
 website_url: https://rhodecode.com/
-description: RhodeCode is an open source platform for software development teams. It unifies and simplifies repository management for Git, Subversion, and Mercurial.
+description: Unify and simplify repository management for Git, Subversion, and Mercurial.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/robust-irc.yml
+++ b/software/robust-irc.yml
@@ -1,6 +1,6 @@
 name: Robust IRC
 website_url: https://robustirc.net/
-description: RobustIRC is IRC without netsplits. Distributed IRC server, based on RobustSession protocol.
+description: IRC without netsplits. Distributed IRC server, based on RobustSession protocol.
 licenses:
   - BSD-3-Clause
 platforms:

--- a/software/rocket.chat.yml
+++ b/software/rocket.chat.yml
@@ -1,6 +1,6 @@
 name: Rocket.Chat
 website_url: https://rocket.chat/
-description: Teamchat solution similar to Gitter.im or Slack.
+description: Communications platform that puts data protection first (alternative to Gitter.im or Slack).
 licenses:
   - MIT
 platforms:

--- a/software/rosariosis.yml
+++ b/software/rosariosis.yml
@@ -1,6 +1,6 @@
 name: RosarioSIS
 website_url: https://www.rosariosis.org/
-description: RosarioSIS, free Student Information System for school management.
+description: Free Student Information System for school management.
 licenses:
   - GPL-2.0
 platforms:

--- a/software/roundup-issue-tracker.yml
+++ b/software/roundup-issue-tracker.yml
@@ -1,6 +1,6 @@
 name: Roundup Issue Tracker
 website_url: https://www.roundup-tracker.org/
-description: A simple-to-use and -install issue-tracking system with command-line, web, REST, XML-RPC, and e-mail interfaces. Designed with flexibility in mind - not just another bug tracker.
+description: Simple-to-use and -install issue tracking system with command-line, web, REST, XML-RPC, and e-mail interfaces. Designed with flexibility in mind - not just another bug tracker.
 licenses:
   - MIT
   - ZPL-2.0

--- a/software/routr.yml
+++ b/software/routr.yml
@@ -1,6 +1,6 @@
 name: Routr
 website_url: https://routr.io
-description: A lightweight sip proxy, location server, and registrar for a reliable and scalable SIP infrastructure.
+description: Lightweight SIP proxy, location server, and registrar for a reliable and scalable SIP infrastructure.
 licenses:
   - MIT
 platforms:

--- a/software/rs-short.yml
+++ b/software/rs-short.yml
@@ -1,7 +1,7 @@
 name: "rs-short"
 website_url: "https://git.42l.fr/42l/rs-short"
 source_code_url: "https://git.42l.fr/42l/rs-short"
-description: "A lightweight link shortener written in Rust, with features such as caching, spambot protection and phishing detection."
+description: "lightweight link shortener written in Rust, with features such as caching, spambot protection and phishing detection."
 licenses:
   - MPL-2.0
 platforms:

--- a/software/rss-monster.yml
+++ b/software/rss-monster.yml
@@ -1,6 +1,6 @@
 name: RSS Monster
 website_url: https://github.com/pietheinstrengholt/rssmonster
-description: An easy to use web-based RSS aggregator and reader compatible with the Fever API (alternative to Google Reader).
+description: Easy to use web-based RSS aggregator and reader compatible with the Fever API (alternative to Google Reader).
 licenses:
   - MIT
 platforms:

--- a/software/rss2email.yml
+++ b/software/rss2email.yml
@@ -1,6 +1,6 @@
 name: RSS2EMail
 website_url: https://github.com/rss2email/rss2email
-description: Fetches RSS/Atom-feeds and pushes new Content to any email-receiver, supports OPML.
+description: Fetches RSS/Atom-feeds and pushes new content to any email-receiver, supports OPML.
 licenses:
   - GPL-2.0
 platforms:

--- a/software/rsshub.yml
+++ b/software/rsshub.yml
@@ -1,7 +1,7 @@
 name: RSSHub
 website_url: https://docs.rsshub.app
 source_code_url: https://github.com/DIYgod/RSSHub
-description: An easy to use, and extensible RSS feed aggregator, it's capable of generating RSS feeds from pretty much everything ranging from social media to university departments.
+description: Easy to use, and extensible RSS feed aggregator, it's capable of generating RSS feeds from pretty much everything ranging from social media to university departments.
 licenses:
   - MIT
 platforms:

--- a/software/rudderstack.yml
+++ b/software/rudderstack.yml
@@ -2,7 +2,7 @@ name: RudderStack
 website_url: https://rudderstack.com/
 description: Collect, unify, transform, and store your customer data, and route it to a wide range of common, popular marketing, sales, and product tools (alternative to Segment).
 licenses:
-  - AGPL-3.0
+  - Elastic-2.0
 platforms:
   - Docker
   - K8S

--- a/software/rustypaste.yml
+++ b/software/rustypaste.yml
@@ -1,6 +1,6 @@
 name: rustypaste
 website_url: https://github.com/orhun/rustypaste
-description: A minimal file upload/pastebin service.
+description: Minimal file upload/pastebin service.
 licenses:
   - MIT
 platforms:

--- a/software/rygel.yml
+++ b/software/rygel.yml
@@ -1,8 +1,8 @@
 name: Rygel
 website_url: https://gnome.pages.gitlab.gnome.org/rygel/
-description: Rygel is a UPnP AV MediaServer that allows you to easily share audio, video, and pictures. Media player software may use Rygel to become a MediaRenderer that may be controlled remotely by a UPnP or DLNA Controller.
+description: UPnP AV MediaServer that allows you to easily share audio, video, and pictures. Media player software may use Rygel to become a MediaRenderer that may be controlled remotely by a UPnP or DLNA Controller.
 licenses:
-  - GPL-3.0
+  - LGPL-2.1
 platforms:
   - C
 tags:

--- a/software/ryot.yml
+++ b/software/ryot.yml
@@ -1,7 +1,7 @@
 name: ryot
 website_url: https://github.com/ignisda/ryot
 source_code_url: https://github.com/ignisda/ryot
-description: Platform for tracking various facets of your life - media, fitness, etc.
+description: Track various facets of your life - media, fitness, etc.
 licenses:
   - GPL-3.0
 platforms:


### PR DESCRIPTION
As part of the series of updating projects, this time for projects beginning with R.

Some chan/ges that may need context are:

Remove Revealjs demo since it is built into the main site.

Rudderstack moves to Non-free due to licese change. [[1](https://github.com/rudderlabs/rudder-server/?tab=License-1-ov-file#readme)]

