### PR TITLE
Update actual website link

### DIFF
--- a/software/actual.yml
+++ b/software/actual.yml
@@ -1,5 +1,5 @@
 name: Actual
-website_url: https://actualbudget.github.io/docs/
+website_url: https://actualbudget.org
 description: Local-first personal finance tool based on zero-sum budgeting, supporting synchronization across devices, custom rules, manual transaction importing (from QIF, OFX, and QFX files), and optional automatic synchronization with many banks.
 licenses:
   - MIT


### PR DESCRIPTION
Updated from https://actualbudget.github.io/docs/ to https://actualbudget.org