### PR TITLE
Add Wallabag to 'Bookmarks' category

### DIFF
--- a/software/wallabag.yml
+++ b/software/wallabag.yml
@@ -7,6 +7,7 @@ platforms:
   - PHP
 tags:
   - Archiving and Digital Preservation (DP)
+  - Bookmarks and Link Sharing
 source_code_url: https://github.com/wallabag/wallabag
 stargazers_count: 11645
 updated_at: '2025-07-02'


### PR DESCRIPTION
Wallabag belongs not just to the `Archiving & DP` category, but should appear under `Bookmarks and Link Sharing` as well, as that is a very common use case for the application. 