### PR TITLE
Remove Demo from GeneWeb

### DIFF
--- a/software/geneweb.yml
+++ b/software/geneweb.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Genealogy
 source_code_url: https://github.com/geneweb/geneweb
-demo_url: https://demo.geneweb.tuxfamily.org/gw7/
 stargazers_count: 353
 updated_at: '2025-07-26'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://demo.geneweb.tuxfamily.org/gw7/ : HTTP 500`
- This demo is now unavailable since over 3 months (https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/15380172608/job/43269848528#step:4:2876)
