### PR TITLE
Remove Demo from LedgerSMB

### DIFF
--- a/software/ledgersmb.yml
+++ b/software/ledgersmb.yml
@@ -9,7 +9,6 @@ platforms:
 tags:
   - Resource Planning
 source_code_url: https://github.com/ledgersmb/LedgerSMB
-demo_url: https://demo.cloud.efficito.com/erp/1.5/login.pl
 stargazers_count: 489
 updated_at: '2025-08-08'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://demo.cloud.efficito.com/erp/1.5/login.pl : HTTP 502`
- This demo is now unavailable since over 3 months (https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/15380172608/job/43269848528#step:4:2888)