### PR TITLE
fix screenconnect url

### DIFF
--- a/software/screenconnect.yml
+++ b/software/screenconnect.yml
@@ -1,5 +1,5 @@
 name: ScreenConnect
-website_url: https://www.connectwise.com/platform/unified-management/control
+website_url: https://www.screenconnect.com/
 description: Lightning-fast remote support and remote access to connect instantly and solve problems faster.
 licenses:
   - ⊘ Proprietary
@@ -7,4 +7,4 @@ platforms:
   - Unknown
 tags:
   - Miscellaneous
-source_code_url: https://www.connectwise.com/platform/unified-management/control
+source_code_url: https://www.screenconnect.com/


### PR DESCRIPTION
- ref: #1
- `https://www.connectwise.com/platform/unified-management/control : HTTP 404`
- The website for ScreenConnect has been removed, Kokomo found that the product now has an extra domain
