### PR TITLE
Publish merged json via automated github action based on yq

### DIFF
--- a/.github/workflows/release-awesome-builds.yml
+++ b/.github/workflows/release-awesome-builds.yml
@@ -1,4 +1,4 @@
-name: Release awesome builds
+name: Release JSON for awesome-data builds
 
 on: 
   push:
@@ -10,12 +10,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Get an entry with a variable that might contain dots or spaces
-        id: get_username
+      - name: Merge software/*.yml into software.json via yq
         uses: mikefarah/yq@master
         with:
           cmd: yq ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml | yq -o=json -I 0 '{\"softwares\":.}' > software.json
-      - name: Test
+      - name: Raw dump software.json
         run: cat software.json
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-awesome-builds.yml
+++ b/.github/workflows/release-awesome-builds.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Merge software/*.yml into software.json via yq
         uses: mikefarah/yq@master
         with:
-          cmd: yq ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml | yq -o=json -I 0 '{\"softwares\":.}' > software.json
+          cmd: yq ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml | yq -o=json -I 0 '{"softwares":.}' > software.json
       - name: Raw dump software.json
         run: cat software.json
       - name: Release

--- a/.github/workflows/release-awesome-builds.yml
+++ b/.github/workflows/release-awesome-builds.yml
@@ -1,6 +1,8 @@
 name: Release awesome builds
 
-on: push
+on: 
+  push:
+    branches: [ master ]
 
 jobs:
   build:
@@ -12,7 +14,7 @@ jobs:
         id: get_username
         uses: mikefarah/yq@master
         with:
-          cmd: yq -o=json -I 0 ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml > software.json
+          cmd: yq ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml | yq -o=json -I 0 '{\"softwares\":.}' > software.json
       - name: Test
         run: cat software.json
       - name: Release

--- a/.github/workflows/release-awesome-builds.yml
+++ b/.github/workflows/release-awesome-builds.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Merge software/*.yml into software.json via yq
         uses: mikefarah/yq@master
         with:
-          cmd: yq ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml | yq -o=json -I 0 '{"softwares":.}' > software.json
+          cmd: yq ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml | yq -o=json -I 2 '{"softwares":.}' > software.json
       - name: Raw dump software.json
         run: cat software.json
       - name: Release

--- a/.github/workflows/release-awesome-builds.yml
+++ b/.github/workflows/release-awesome-builds.yml
@@ -1,8 +1,6 @@
 name: Release JSON for awesome-data builds
 
-on: 
-  push:
-    branches: [ master ]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/release-awesome-builds.yml
+++ b/.github/workflows/release-awesome-builds.yml
@@ -1,0 +1,22 @@
+name: Release awesome builds
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Get an entry with a variable that might contain dots or spaces
+        id: get_username
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -o=json -I 0 ea '[.] as $item ireduce ([]; . *+ $item )' software/*.yml > software.json
+      - name: Test
+        run: cat software.json
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: software.json


### PR DESCRIPTION
Following https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/1608 here is a github action that relies on yq to push a json build on release. 

Some notes
 - Workflow Runs in less than 10s
 - file-size: 492KB without indentation (one-line json), 670KB with 2-spaces indentation and simplifies reading a lot so used this. 
 - JSON object root is `{software: [yaml_list_transpiled_to_json}` to make it a valid json - could not be an array at root level.
 - Example release here https://github.com/jo-chemla/awesome-selfhosted-data/releases/tag/0.1.4 and [software.json](https://github.com/jo-chemla/awesome-selfhosted-data/releases/download/0.1.4/software.json) file