### PR TITLE
update source code URLs

### DIFF
--- a/software/acp-admin.yml
+++ b/software/acp-admin.yml
@@ -7,7 +7,7 @@ platforms:
   - Ruby
 tags:
   - Community-Supported Agriculture (CSA)
-source_code_url: https://github.com/acp-admin/acp-admin/
+source_code_url: https://github.com/csa-admin-org/csa-admin
 stargazers_count: 57
 updated_at: '2025-08-29'
 archived: false

--- a/software/answer.yml
+++ b/software/answer.yml
@@ -8,7 +8,7 @@ platforms:
   - Go
 tags:
   - Communication - Social Networks and Forums
-source_code_url: https://github.com/answerdev/answer
+source_code_url: https://github.com/apache/answer
 stargazers_count: 14848
 updated_at: '2025-07-17'
 archived: false

--- a/software/atsumeru.yml
+++ b/software/atsumeru.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Document Management - E-books
-source_code_url: https://github.com/AtsumeruDev/Atsumeru
+source_code_url: https://github.com/Atsumeru-xyz/Atsumeru
 related_software_url: https://atsumeru.xyz/guides/#how-does-it-work
 stargazers_count: 142
 updated_at: '2025-07-14'

--- a/software/black-candy.yml
+++ b/software/black-candy.yml
@@ -1,5 +1,5 @@
 name: Black Candy
-website_url: https://github.com/blackcandy-org/black_candy
+website_url: https://github.com/blackcandy-org/blackcandy
 description: Music streaming server.
 licenses:
   - MIT
@@ -8,7 +8,7 @@ platforms:
   - Ruby
 tags:
   - Media Streaming - Audio Streaming
-source_code_url: https://github.com/blackcandy-org/black_candy
+source_code_url: https://github.com/blackcandy-org/blackcandy
 stargazers_count: 3881
 updated_at: '2025-07-09'
 archived: false

--- a/software/blinko.yml
+++ b/software/blinko.yml
@@ -7,7 +7,7 @@ platforms:
   - Docker
 tags:
   - Note-taking & Editors
-source_code_url: https://github.com/blinko-space/blinko
+source_code_url: https://github.com/blinkospace/blinko
 stargazers_count: 5728
 updated_at: '2025-08-28'
 archived: false

--- a/software/booklore.yml
+++ b/software/booklore.yml
@@ -1,6 +1,6 @@
 name: BookLore
-website_url: https://github.com/adityachandelgit/BookLore
-source_code_url: https://github.com/adityachandelgit/BookLore
+website_url: https://github.com/booklore-app/booklore
+source_code_url: https://github.com/booklore-app/booklore
 description: Host and manage books, with support for PDFs, eBooks, reading progress, metadata, and stats.
 licenses:
   - GPL-3.0

--- a/software/eclipse-che.yml
+++ b/software/eclipse-che.yml
@@ -8,7 +8,7 @@ platforms:
   - Java
 tags:
   - Software Development - IDE & Tools
-source_code_url: https://github.com/eclipse/che
+source_code_url: https://github.com/eclipse-che/che
 stargazers_count: 7072
 updated_at: '2025-08-27'
 archived: false

--- a/software/element.yml
+++ b/software/element.yml
@@ -7,7 +7,7 @@ platforms:
   - Nodejs
 tags:
   - Communication - Custom Communication Systems
-source_code_url: https://github.com/vector-im/element-web
+source_code_url: https://github.com/element-hq/element-web
 stargazers_count: 12022
 updated_at: '2025-08-29'
 archived: false

--- a/software/flowforge.yml
+++ b/software/flowforge.yml
@@ -9,7 +9,7 @@ platforms:
   - K8S
 tags:
   - Internet of Things (IoT)
-source_code_url: https://github.com/flowforge/flowforge
+source_code_url: https://github.com/FlowFuse/flowfuse
 stargazers_count: 343
 updated_at: '2025-08-29'
 archived: false

--- a/software/focalboard.yml
+++ b/software/focalboard.yml
@@ -11,7 +11,7 @@ platforms:
   - Docker
 tags:
   - Task Management & To-do Lists
-source_code_url: https://github.com/mattermost/focalboard
+source_code_url: https://github.com/mattermost-community/focalboard
 related_software_url: https://www.focalboard.com/download/personal-edition/desktop/
 stargazers_count: 24877
 updated_at: '2025-06-11'

--- a/software/freescout.yml
+++ b/software/freescout.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Ticketing
-source_code_url: https://github.com/freescout-helpdesk/freescout
+source_code_url: https://github.com/freescout-help-desk/freescout
 demo_url: https://demo.freescout.net/login
 stargazers_count: 3741
 updated_at: '2025-08-18'

--- a/software/globaleaks.yml
+++ b/software/globaleaks.yml
@@ -1,6 +1,6 @@
 name: GlobaLeaks
 website_url: https://www.globaleaks.org/
-source_code_url: https://github.com/globaleaks/whistleblowing-software
+source_code_url: https://github.com/globaleaks/globaleaks-whistleblowing-software
 demo_url: https://demo.globaleaks.org
 description: Whistleblowing software enabling anyone to easily set up and maintain a secure reporting platform.
 licenses:

--- a/software/inginious.yml
+++ b/software/inginious.yml
@@ -1,6 +1,6 @@
 name: INGInious
 website_url: https://inginious.org/?lang=en
-source_code_url: https://github.com/UCL-INGI/INGInious
+source_code_url: https://github.com/INGInious/INGInious
 description: Intelligent grader that allows secured and automated testing of code made by students.
 licenses:
   - AGPL-3.0
@@ -9,7 +9,7 @@ platforms:
   - Docker
 tags:
   - Learning and Courses
-related_software_url: https://github.com/UCL-INGI/INGInious-plugins
+related_software_url: https://github.com/INGInious/plugins
 stargazers_count: 226
 updated_at: '2025-07-24'
 archived: false

--- a/software/isso.yml
+++ b/software/isso.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Communication - Social Networks and Forums
-source_code_url: https://github.com/posativ/isso
+source_code_url: https://github.com/isso-comments/isso
 stargazers_count: 5177
 updated_at: '2025-08-14'
 archived: false

--- a/software/jina.yml
+++ b/software/jina.yml
@@ -1,5 +1,5 @@
 name: Jina
-website_url: https://github.com/jina-ai/jina/
+website_url: https://github.com/jina-ai/serve
 description: Cloud-native neural search framework for any kind of data.
 licenses:
   - Apache-2.0
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Search Engines
-source_code_url: https://github.com/jina-ai/jina/
+source_code_url: https://github.com/jina-ai/serve
 stargazers_count: 21710
 updated_at: '2025-03-24'
 archived: false

--- a/software/mataroa.yml
+++ b/software/mataroa.yml
@@ -7,7 +7,7 @@ platforms:
   - Python
 tags:
   - Blogging Platforms
-source_code_url: https://github.com/mataroa-blog/mataroa
+source_code_url: https://github.com/mataroablog/mataroa
 stargazers_count: 300
 updated_at: '2025-08-24'
 archived: false

--- a/software/mathesar.yml
+++ b/software/mathesar.yml
@@ -8,7 +8,7 @@ platforms:
   - Python
 tags:
   - Database Management
-source_code_url: https://github.com/centerofci/mathesar
+source_code_url: https://github.com/mathesar-foundation/mathesar
 stargazers_count: 4389
 updated_at: '2025-08-25'
 archived: false

--- a/software/mejiro.yml
+++ b/software/mejiro.yml
@@ -1,5 +1,5 @@
 name: Mejiro
-website_url: https://github.com/dmpop/mejiro
+website_url: https://github.com/dmpop/pellicola
 description: Easy-to-use instant photo publishing.
 licenses:
   - GPL-3.0
@@ -7,7 +7,7 @@ platforms:
   - PHP
 tags:
   - Photo Galleries
-source_code_url: https://github.com/dmpop/mejiro
+source_code_url: https://github.com/dmpop/pellicola
 stargazers_count: 184
 updated_at: '2025-05-27'
 archived: false

--- a/software/qloapps.yml
+++ b/software/qloapps.yml
@@ -8,7 +8,7 @@ platforms:
   - Nodejs
 tags:
   - Booking and Scheduling
-source_code_url: https://github.com/webkul/hotelcommerce
+source_code_url: https://github.com/Qloapps/QloApps
 demo_url: https://demo.qloapps.com/
 stargazers_count: 7612
 updated_at: '2025-07-07'

--- a/software/reaparr.yml
+++ b/software/reaparr.yml
@@ -1,6 +1,6 @@
-name: PlexRipper
-website_url: https://www.plexripper.rocks/
-source_code_url: https://github.com/PlexRipper/PlexRipper
+name: Reaparr
+website_url: https://www.reaparr.rocks/
+source_code_url: https://github.com/Reaparr/Reaparr
 description: Cross-platform Plex media downloader that seamlessly adds media from other Plex servers to your own.
 licenses:
   - GPL-3.0

--- a/software/seatsurfing.yml
+++ b/software/seatsurfing.yml
@@ -7,7 +7,7 @@ platforms:
   - Docker
 tags:
   - Booking and Scheduling
-source_code_url: https://github.com/seatsurfing/backend
+source_code_url: https://github.com/seatsurfing/seatsurfing
 stargazers_count: 243
 updated_at: '2025-08-25'
 archived: false

--- a/software/shopware-community-edition.yml
+++ b/software/shopware-community-edition.yml
@@ -7,7 +7,7 @@ platforms:
   - PHP
 tags:
   - E-commerce
-source_code_url: https://github.com/shopware/platform
+source_code_url: https://github.com/shopware/shopware
 demo_url: https://www.shopware.com/en/test-demo/
 stargazers_count: 3153
 updated_at: '2025-08-29'

--- a/software/sist2.yml
+++ b/software/sist2.yml
@@ -1,5 +1,5 @@
 name: sist2
-website_url: https://github.com/simon987/sist2
+website_url: https://github.com/sist2app/sist2
 description: Lightning-fast file system indexer and search tool.
 licenses:
   - GPL-3.0
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Search Engines
-source_code_url: https://github.com/simon987/sist2
+source_code_url: https://github.com/sist2app/sist2
 stargazers_count: 1125
 updated_at: '2025-07-05'
 archived: false

--- a/software/slash.yml
+++ b/software/slash.yml
@@ -1,6 +1,6 @@
 name: Slash
-website_url: https://github.com/boojack/slash
-source_code_url: https://github.com/boojack/slash
+website_url: https://github.com/yourselfhosted/slash
+source_code_url: https://github.com/yourselfhosted/slash
 description: An open source, self-hosted bookmarks and link sharing platform.
 licenses:
   - GPL-3.0

--- a/software/stalwart-mail-server.yml
+++ b/software/stalwart-mail-server.yml
@@ -1,6 +1,6 @@
 name: Stalwart Mail Server
 website_url: https://stalw.art
-source_code_url: https://github.com/stalwartlabs/mail-server
+source_code_url: https://github.com/stalwartlabs/stalwart
 description: All-in-one mail server with JMAP, IMAP4, and SMTP support and a wide range of modern features.
 licenses:
   - AGPL-3.0

--- a/software/stirling-pdf.yml
+++ b/software/stirling-pdf.yml
@@ -1,5 +1,5 @@
 name: Stirling-PDF
-website_url: https://github.com/Frooodle/Stirling-PDF
+website_url: https://github.com/Stirling-Tools/Stirling-PDF
 description: Local hosted web application that allows you to perform various operations on PDF files, such as merging, splitting, file conversions and OCR.
 licenses:
   - Apache-2.0
@@ -8,7 +8,7 @@ platforms:
   - Java
 tags:
   - Document Management
-source_code_url: https://github.com/Frooodle/Stirling-PDF
+source_code_url: https://github.com/Stirling-Tools/Stirling-PDF
 stargazers_count: 64775
 updated_at: '2025-08-28'
 archived: false

--- a/software/suitecrm.yml
+++ b/software/suitecrm.yml
@@ -7,7 +7,7 @@ platforms:
   - PHP
 tags:
   - Customer Relationship Management (CRM)
-source_code_url: https://github.com/salesagility/SuiteCRM
+source_code_url: https://github.com/SuiteCRM/SuiteCRM
 stargazers_count: 5024
 updated_at: '2025-08-26'
 archived: false

--- a/software/swingmusic.yml
+++ b/software/swingmusic.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Media Streaming - Audio Streaming
-source_code_url: https://github.com/swing-opensource/swingmusic
+source_code_url: https://github.com/swingmx/swingmusic
 stargazers_count: 1261
 updated_at: '2025-08-29'
 archived: false

--- a/software/teslamate.yml
+++ b/software/teslamate.yml
@@ -1,5 +1,5 @@
 name: TeslaMate
-website_url: https://github.com/adriankumpf/teslamate
+website_url: https://github.com/teslamate-org/teslamate
 description: A powerful data logger for Tesla vehicles.
 licenses:
   - MIT
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Miscellaneous
-source_code_url: https://github.com/adriankumpf/teslamate
+source_code_url: https://github.com/teslamate-org/teslamate
 stargazers_count: 7071
 updated_at: '2025-08-20'
 archived: false

--- a/software/tiddlywiki.yml
+++ b/software/tiddlywiki.yml
@@ -7,7 +7,7 @@ platforms:
   - Nodejs
 tags:
   - Wikis
-source_code_url: https://github.com/Jermolene/TiddlyWiki5
+source_code_url: https://github.com/TiddlyWiki/TiddlyWiki5
 stargazers_count: 8395
 updated_at: '2025-08-29'
 archived: false

--- a/software/tipi.yml
+++ b/software/tipi.yml
@@ -7,7 +7,7 @@ platforms:
   - Shell
 tags:
   - Self-hosting Solutions
-source_code_url: https://github.com/meienberger/runtipi
+source_code_url: https://github.com/runtipi/runtipi
 stargazers_count: 8764
 updated_at: '2025-08-24'
 archived: false

--- a/software/txtdot.yml
+++ b/software/txtdot.yml
@@ -1,6 +1,6 @@
 name: txtdot
 website_url: https://tempoworks.github.io/documentation
-source_code_url: https://github.com/TxtDot/txtdot
+source_code_url: https://github.com/TempoWorks/txtdot
 description: A HTTP proxy that parses only text, links and pictures from pages reducing internet bandwidth usage, removing ads and heavy scripts.
 licenses:
   - MIT

--- a/software/wildduck.yml
+++ b/software/wildduck.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Communication - Email - Complete Solutions
-source_code_url: https://github.com/nodemailer/wildduck
+source_code_url: https://github.com/zone-eu/wildduck
 stargazers_count: 2026
 updated_at: '2025-08-26'
 archived: false

--- a/software/workadventure.yml
+++ b/software/workadventure.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Communication - Custom Communication Systems
-source_code_url: https://github.com/thecodingmachine/workadventure/
+source_code_url: https://github.com/workadventure/workadventure
 demo_url: https://play.staging.workadventu.re/@/tcm/workadventure/wa-village
 stargazers_count: 4891
 updated_at: '2025-08-27'

--- a/software/yt-dlp-web-ui.yml
+++ b/software/yt-dlp-web-ui.yml
@@ -1,5 +1,5 @@
 name: yt-dlp Web UI
-website_url: https://github.com/marcopeocchi/yt-dlp-web-ui
+website_url: https://github.com/marcopiovanello/yt-dlp-web-ui
 description: Web GUI for yt-dlp.
 licenses:
   - MPL-2.0
@@ -9,7 +9,7 @@ platforms:
   - Nodejs
 tags:
   - Media Management
-source_code_url: https://github.com/marcopeocchi/yt-dlp-web-ui
+source_code_url: https://github.com/marcopiovanello/yt-dlp-web-ui
 stargazers_count: 1880
 updated_at: '2025-08-28'
 archived: false


### PR DESCRIPTION
In the latest run of update-metadata i noticed that a lot of repos have changed their source-code.
This PR updates these URLs.

Additionally it re-names PlexRipper to Reaparr (source-code url, name, website, etc. changed)