### PR TITLE
Update Drop

### DIFF
--- a/software/drop.yml
+++ b/software/drop.yml
@@ -8,7 +8,6 @@ platforms:
   - Docker
 tags:
   - Games - Administrative Utilities & Control Panels
-depends_3rdparty: false
 related_software_url: https://github.com/Drop-OSS/drop-app
 stargazers_count: 454
 updated_at: '2025-08-31'


### PR DESCRIPTION
Resolves #1623 as Drop does not require any 3rd party services, although they may be added optionally