### PR TITLE
Add tags knowledge-management-tools, office-suites, wikis to Seafile

### DIFF
--- a/software/seafile.yml
+++ b/software/seafile.yml
@@ -10,6 +10,9 @@ platforms:
   - C
 tags:
   - File Transfer & Synchronization
+  - knowledge-management-tools
+  - office-suites
+  - wikis
 source_code_url: https://github.com/haiwen/seafile
 stargazers_count: 13652
 updated_at: '2025-08-06'


### PR DESCRIPTION
This PR updates the Seafile entry to include the following tags:
- knowledge-management-tools
- office-suites
- wikis

Rationale / evidence:
- SeaDoc: Seafile provides an integrated collaborative document editor (SeaDoc) and knowledge-management features. See SeaDoc docs: https://haiwen.github.io/seafile-admin-docs/... . :contentReference[oaicite:6]{index=6}
- Wiki feature: Seafile 12.x announced a wiki/knowledge-base feature for team knowledge management. :contentReference[oaicite:7]{index=7}
- Office integration: Seafile supports integration with Collabora/OnlyOffice for online editing of Office formats. :contentReference[oaicite:8]{index=8}

Files changed:
- software/seafile.yml (tags: added knowledge-management-tools, office-suites, wikis)

Please let me know if any formatting or metadata needs adjustment; happy to fix.
