### PR TITLE
Add tags knowledge-management-tools, office-suites, wikis and update Seafile entry

### DIFF
--- a/software/seafile.yml
+++ b/software/seafile.yml
@@ -10,6 +10,9 @@ platforms:
   - C
 tags:
   - File Transfer & Synchronization
+  - knowledge-management-tools
+  - office-suites
+  - wikis
 source_code_url: https://github.com/haiwen/seafile
 stargazers_count: 13652
 updated_at: '2025-08-06'


### PR DESCRIPTION
This PR:
- Adds three tag definitions: knowledge-management-tools, office-suites, wikis (in tags/tags.yml)
- Updates the Seafile entry (software/seafile.yml) to include these tags

Rationale / evidence:
- SeaDoc and wiki-like knowledge features in Seafile (SeaDoc). 
- Support for online office editing via Collabora/OnlyOffice integrations.

Please let me know if you prefer different slug names or shorter descriptions.