### PR TITLE
fix target name for strict linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ awesome_lint:
 	source .venv/bin/activate && \
 	hecat --config .hecat/awesome-lint.yml
 
-.PHONY: awesome_lint # check data against awesome-selfhosted guidelines (strict)
+.PHONY: awesome_lint_strict # check data against awesome-selfhosted guidelines (strict)
 awesome_lint_strict:
 	source .venv/bin/activate && \
 	hecat --config .hecat/awesome-lint-strict.yml


### PR DESCRIPTION
There was a small bug with make help command.
It returned 2x the argument awesome_lint instead of the correct arguments.

<img width="653" height="266" alt="2025-09-19-19-40_1070" src="https://github.com/user-attachments/assets/06028a09-0844-46df-9a44-4e085afeb509" />
