### PR TITLE
fix the-epube website URL

### DIFF
--- a/software/the-epube.yml
+++ b/software/the-epube.yml
@@ -1,5 +1,5 @@
 name: The Epube
-website_url: https://gitlab.tt-rss.org/main/the-epube/-/wikis/home
+website_url: https://tt-rss.org/ZeEpube/
 description: Self-hosted web EPUB reader using EPUB.js, Bootstrap, and Calibre.
 licenses:
   - GPL-3.0


### PR DESCRIPTION
- ref: #1
- `https://gitlab.tt-rss.org/main/the-epube/-/wikis/home : HTTP 403`
