### PR TITLE
remove demo from flipt

### DIFF
--- a/software/flipt.yml
+++ b/software/flipt.yml
@@ -10,7 +10,6 @@ platforms:
   - Go
 tags:
   - Software Development - Feature Toggle
-demo_url: https://try.flipt.io
 stargazers_count: 4567
 updated_at: '2025-09-23'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://try.flipt.io : HTTPSConnectionPool(host='try.flipt.io', port=443): Max retries exceeded with url: / (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fb63326d0a0>: Failed to resolve 'try.flipt.io' ([Errno -2] Name or service not known)"))`
- Demo seems to be removed from GitHub and website
