### PR TITLE
fix: gotosocial source unavailable

### DIFF
--- a/software/gotosocial.yml
+++ b/software/gotosocial.yml
@@ -8,7 +8,4 @@ platforms:
   - Go
 tags:
   - Communication - Social Networks and Forums
-source_code_url: https://github.com/superseriousbusiness/gotosocial
-stargazers_count: 4167
-updated_at: '2025-10-08'
-archived: false
+source_code_url: https://codeberg.org/superseriousbusiness/gotosocial


### PR DESCRIPTION
- ref: #1
- Source has been removed for GitHub, the offical website points to Codeberg now.
- Also fixes current metadate job error