### PR TITLE
Change Answer website url to match source code url

### DIFF
--- a/software/answer.yml
+++ b/software/answer.yml
@@ -1,5 +1,5 @@
 name: Answer
-website_url: https://answer.dev/
+website_url: https://answer.apache.org
 description: Knowledge-based community software. You can use it to quickly build your Q&A community for product technical support, customer support, user communication, and more.
 licenses:
   - Apache-2.0
@@ -10,5 +10,5 @@ tags:
   - Communication - Social Networks and Forums
 source_code_url: https://github.com/apache/answer
 stargazers_count: 15040
-updated_at: '2025-09-02'
+updated_at: '2025-10-21'
 archived: true


### PR DESCRIPTION
Was pointing to answer.dev which wasn't FOSS much