### PR TITLE
update: tt-rrs source

### DIFF
--- a/software/tiny-tiny-rss.yml
+++ b/software/tiny-tiny-rss.yml
@@ -1,6 +1,6 @@
 name: Tiny Tiny RSS
 website_url: https://tt-rss.org
-description: Open source web-based news feed (RSS/Atom) reader and aggregator.
+description: Web-based news feed (RSS/Atom) reader and aggregator.
 licenses:
   - GPL-3.0
 platforms:
@@ -8,5 +8,4 @@ platforms:
   - PHP
 tags:
   - Feed Readers
-source_code_url: https://git.tt-rss.org/fox/tt-rss
-demo_url: https://demo.tt-rss.org/
+source_code_url: https://github.com/tt-rss/tt-rss


### PR DESCRIPTION
closes #1752 

- Update source url to point to the new repo
- Removes Demo, as there is no longer a public facing service
- Removes `open source` from description