### PR TITLE
update Umami demo URL

### DIFF
--- a/software/umami.yml
+++ b/software/umami.yml
@@ -9,7 +9,7 @@ platforms:
 tags:
   - Analytics
 source_code_url: https://github.com/umami-software/umami
-demo_url: https://analytics.umami.is/share/LGazGOecbDtaIwDr/umami.is
+demo_url: https://cloud.umami.is/share/LGazGOecbDtaIwDr
 stargazers_count: 33502
 updated_at: '2025-11-11'
 archived: false


### PR DESCRIPTION
- ref: #1
- `ERROR:url_check.py: [1171/1422] https://analytics.umami.is/share/LGazGOecbDtaIwDr/umami.is : HTTP 404`
