### PR TITLE
update FileRun URLs

### DIFF
--- a/software/filerun.yml
+++ b/software/filerun.yml
@@ -1,5 +1,5 @@
 name: FileRun
-website_url: https://www.filerun.com/
+website_url: https://filerun.com/
 description: Complete solution for your files with integration with Google and Office.
 licenses:
   - ⊘ Proprietary
@@ -7,5 +7,5 @@ platforms:
   - PHP
 tags:
   - File Transfer & Synchronization
-source_code_url: https://www.filerun.com/
-demo_url: https://www.filerun.com/demo
+source_code_url: https://filerun.com/
+demo_url: https://filerun.com/demo


### PR DESCRIPTION
- ref: #1
- `https://www.filerun.com/ : HTTPSConnectionPool(host='www.filerun.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1000)')))`
- `https://www.filerun.com/demo : HTTPSConnectionPool(host='www.filerun.com', port=443): Max retries exceeded with url: /demo (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1000)')))`
