### PR TITLE
tools: Makefile: update hecat to 1.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	python3 -m venv .venv
 	source .venv/bin/activate && \
 	pip3 install wheel && \
-	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.5.0
+	pip3 install --force git+https://github.com/nodiscc/hecat.git@1.5.1
 
 .PHONY: import # import data from the original list at https://github.com/awesome-selfhosted/awesome-selfhosted
 import: clean install


### PR DESCRIPTION
- https://github.com/nodiscc/hecat/releases/tag/1.5.1
- partial fix for https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/1828, metadata for 2025-08 still wrong on multiple projects, make update_metadata should be run manually with >= 4 months history
