### PR TITLE
adventurelog fix erroneous demo link

### DIFF
--- a/software/adventurelog.yml
+++ b/software/adventurelog.yml
@@ -9,8 +9,8 @@ platforms:
 tags:
   - Maps and Global Positioning System (GPS)
 demo_url: https://demo.adventurelog.app/signup
-stargazers_count: 2389
-updated_at: '2025-11-06'
+stargazers_count: 2417
+updated_at: '2025-12-10'
 archived: false
 current_release:
   tag: v0.11.0


### PR DESCRIPTION
Old Adventure Log demo website link took to the main [website](https://adventurelog.app/), whilst a [demo](https://demo.adventurelog.app/) is available. Link should point to the demo directly.
