### PR TITLE
Restore Bolt-CMS

### DIFF
--- a/software/bolt-cms.yml
+++ b/software/bolt-cms.yml
@@ -8,6 +8,3 @@ platforms:
 tags:
   - Content Management Systems (CMS)
 source_code_url: https://github.com/bolt/core
-stargazers_count: 582
-updated_at: '2025-12-18'
-archived: false


### PR DESCRIPTION
Reverts https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/1120. Resubmit of #1175, as requested.

The removal just crossed the organisation takeover we were working on after the main maintainer has passed last year. I am one of the new maintainers of the project and have made quite some new releases (https://github.com/bolt/core/releases). The first couple of betas for version 6 have also been released, first RC should land this month.