### PR TITLE
fix yeti-switch demo URL

### DIFF
--- a/software/yeti-switch.yml
+++ b/software/yeti-switch.yml
@@ -9,4 +9,4 @@ platforms:
 tags:
   - Communication - SIP
 source_code_url: https://github.com/yeti-switch
-demo_url: https://yeti-switch.org/demo.html
+demo_url: https://demo.yeti-switch.org/


### PR DESCRIPTION
- ref: #1
- `https://yeti-switch.org/demo.html : HTTP 404`
- A new Demo URL is linked from the main site
