### PR TITLE
Add Shimmy - Self-hosted AI inference server

### DIFF
--- a/software/shimmy.yml
+++ b/software/shimmy.yml
@@ -1,0 +1,12 @@
+name: Shimmy
+website_url: https://github.com/Michael-A-Kuykendall/shimmy
+source_code_url: https://github.com/Michael-A-Kuykendall/shimmy
+description: Self-hosted OpenAI-compatible inference server with Rust performance. Supports multiple model formats with streaming and multimodal capabilities.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Generative Artificial Intelligence
+depends_3rdparty: false


### PR DESCRIPTION
Adding Shimmy, a self-hosted OpenAI-compatible inference server built in Rust.

**Why it's awesome:** Provides local AI inference with OpenAI API compatibility, eliminating dependency on external services while maintaining familiar APIs. Built in Rust for performance and safety.

**Details:**
- 3500+ stars
- 4+ months old
- Actively maintained
- MIT license
- Supports multiple model formats and streaming

Meets all requirements for inclusion.