### PR TITLE
docs/issue: add to addion template a note to not delete the checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/addition.md
+++ b/.github/ISSUE_TEMPLATE/addition.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
+
 Thanks for taking the time to suggest an addition to awesome-selfhosted! 
 
 Please fill out information below (all fields are mandatory unless noted otherwise):


### PR DESCRIPTION
Similar as how we have done it for the PR Template, add a note in the addition issue template to not delete the template, so users don't remove our check boxes, or change the format completely.