### PR TITLE
update repo URL for Karaoke Eternal

### DIFF
--- a/software/karaoke-eternal.yml
+++ b/software/karaoke-eternal.yml
@@ -8,4 +8,4 @@ platforms:
   - Nodejs
 tags:
   - Media Streaming - Multimedia Streaming
-source_code_url: https://www.karaoke-eternal.com/repo
+source_code_url: https://github.com/bhj/KaraokeEternal


### PR DESCRIPTION
Use the GitHub URL directly since the bot doesn't seem to be following the redirect