### PR TITLE
Add n8n Install

### DIFF
--- a/software/n8n-install.yml
+++ b/software/n8n-install.yml
@@ -1,0 +1,11 @@
+name: "n8n Install"
+website_url: "https://github.com/kossakovsky/n8n-install"
+source_code_url: "https://github.com/kossakovsky/n8n-install"
+description: "Self-hosted AI automation platform. Deploy n8n with 30 AI tools (Ollama, Open WebUI, Supabase, Qdrant, etc.) using one command. Auto HTTPS via Caddy."
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+tags:
+  - Self-hosting Solutions
+  - Automation


### PR DESCRIPTION
Adds n8n Install — a Docker Compose solution for deploying n8n with AI infrastructure.

**Key features:**
- One-command deployment of n8n + 30 optional services (Ollama, Open WebUI, Supabase, Qdrant, etc.)
- Automatic HTTPS via Caddy reverse proxy
- Interactive wizard for service selection during setup
- Queue mode with scalable workers for high-load workflows
- Optional import of 300+ community workflows

**Stats:** 622 stars, 171 forks, 500+ commits, actively maintained

**Age:** Created May 2025 (8+ months ago)

Fits under "Self-hosting Solutions" as it simplifies installation and management of self-hosted AI automation infrastructure.