### PR TITLE
Rename Revolt to Stoat, update licenses

### DIFF
--- a/software/stoat.yml
+++ b/software/stoat.yml
@@ -1,13 +1,14 @@
-name: Revolt
-website_url: https://revolt.chat/
-description: Revolt is a user-first chat platform built with modern web technologies.
+name: Stoat
+website_url: https://stoat.chat/
+description: Stoat is a user-first chat platform built with modern web technologies.
 licenses:
   - AGPL-3.0
+  - MIT
 platforms:
   - Rust
 tags:
   - Communication - Custom Communication Systems
-source_code_url: https://github.com/revoltchat/self-hosted
+source_code_url: https://github.com/stoatchat/self-hosted
 stargazers_count: 492
 updated_at: '2025-11-24'
 archived: false


### PR DESCRIPTION
Project changed name from Revolt to Stoat (see: https://stoat.chat/updates/long-live-stoat).

Some parts of the software have been relicensed from `AGPL-3.0-or-later` to `MIT` (see: https://github.com/stoatchat/stoatchat/commit/4c6e78e1a522a02148c816d4541bf2c82049f341 ).