### PR TITLE
update NocoDB license (non-free)

### DIFF
--- a/licenses-nonfree.yml
+++ b/licenses-nonfree.yml
@@ -48,6 +48,10 @@
   name: Server Side Public License
   url: https://spdx.org/licenses/SSPL-1.0.html
 
+- identifier: SUL-1.0
+  name: Sustainable Use License v1.0
+  url: https://spdx.org/licenses/SUL-1.0.html
+
 - identifier: ⊘ Proprietary
   name: Proprietary software
   url: https://en.wikipedia.org/wiki/Proprietary_software

--- a/software/nocodb.yml
+++ b/software/nocodb.yml
@@ -2,7 +2,7 @@ name: NocoDB
 website_url: https://www.nocodb.com/
 description: No-code platform that turns any database into a smart spreadsheet (alternative to Airtable and Smartsheet).
 licenses:
-  - AGPL-3.0
+  - SUL-1.0
 platforms:
   - Nodejs
   - Docker


### PR DESCRIPTION
Updates the license of NocoDB to the Sustainable Use License v1.0
closes #1935