### PR TITLE
BinPastes: remove demo url

### DIFF
--- a/software/binpastes.yml
+++ b/software/binpastes.yml
@@ -1,7 +1,6 @@
 name: BinPastes
 website_url: https://github.com/querwurzel/BinPastes
 source_code_url: https://github.com/querwurzel/BinPastes
-demo_url: https://paste.wylke.it
 description: Minimal pastebin supporting client-side encryption, fulltext search, one-time messages. Intended for one to few users looking for a simple pastebin deployment.
 licenses:
   - Apache-2.0


### PR DESCRIPTION
Removing the demo url, the software still lives