### PR TITLE
Add OneUptime - complete open-source observability platform

### DIFF
--- a/software/oneuptime.yml
+++ b/software/oneuptime.yml
@@ -1,0 +1,13 @@
+name: OneUptime
+website_url: https://oneuptime.com/
+description: Complete observability platform with uptime monitoring, status pages, incident management, on-call scheduling, logs, traces, metrics, and error tracking. Replaces Pingdom, StatusPage.io, PagerDuty, Datadog, and Sentry.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+  - K8S
+tags:
+  - Monitoring
+  - Status / Uptime pages
+source_code_url: https://github.com/OneUptime/oneuptime
+demo_url: https://oneuptime.com/


### PR DESCRIPTION
## OneUptime

[OneUptime](https://oneuptime.com/) is a complete open-source observability platform that combines:

- **Uptime Monitoring** - Monitor websites, APIs, and services from multiple global locations
- **Status Pages** - Public and private status pages for communicating with customers
- **Incident Management** - Collaborative incident workflow with timelines and post-mortems
- **On-Call Scheduling** - Schedules, escalation policies, and alerting
- **Logs Management** - Centralized log collection and analysis
- **APM / Traces** - Application performance monitoring with distributed tracing
- **Metrics** - Infrastructure and custom metrics
- **Error Tracking** - Exception monitoring and debugging

It replaces multiple tools (Pingdom, StatusPage.io, PagerDuty, Datadog, Sentry) with a single self-hosted platform.

**License:** Apache-2.0
**GitHub:** https://github.com/OneUptime/oneuptime (6,400+ stars)
**Deployment:** Docker, Kubernetes (Helm chart on ArtifactHub)

Categories: Monitoring, Status / Uptime pages