### PR TITLE
chore(librebooking): update GitHub repo URL after rename

### DIFF
--- a/software/librebooking.yml
+++ b/software/librebooking.yml
@@ -1,6 +1,6 @@
 name: LibreBooking
 website_url: https://librebooking.readthedocs.io/
-source_code_url: https://github.com/LibreBooking/app
+source_code_url: https://github.com/LibreBooking/librebooking
 demo_url: https://librebooking-demo.fly.dev/
 description: Resource scheduling solution offering a flexible, mobile-friendly, and extensible interface for organizations to manage resource reservations.
 licenses:


### PR DESCRIPTION
It is still located withing the same organization as before.

The LibreBooking GitHub repo was renamed:

  * New URL:      https://github.com/LibreBooking/librebooking
  * Previous URL: https://github.com/LibreBooking/app

The old link still works, it just gets redirected to the new link. But it is recommended to update the links.