### PR TITLE
Add OneUptime

### DIFF
--- a/software/oneuptime.yml
+++ b/software/oneuptime.yml
@@ -1,0 +1,12 @@
+name: OneUptime
+website_url: https://oneuptime.com/
+source_code_url: https://github.com/OneUptime/oneuptime
+description: Complete observability platform with uptime monitoring, status pages, incident management, on-call scheduling, logs, traces, and error tracking.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+  - K8S
+tags:
+  - Status / Uptime pages
+demo_url: https://oneuptime.com/


### PR DESCRIPTION
## Add OneUptime

- **Website:** https://oneuptime.com/
- **Source Code:** https://github.com/OneUptime/oneuptime (4.5k+ stars, actively maintained)
- **License:** Apache-2.0
- **Platforms:** Docker, Kubernetes
- **Category:** Status / Uptime pages
- **Demo:** https://oneuptime.com/

### Description

OneUptime is a complete open-source observability platform that includes uptime monitoring, status pages, incident management, on-call scheduling, logs, traces, and error tracking.

### Checklist

- [x] Single item submission
- [x] Searched for existing issues/PRs
- [x] Not listed on awesome-sysadmin, staticgen, etc.
- [x] Actively maintained (regular commits)
- [x] First released more than 4 months ago
- [x] Working installation instructions available