### PR TITLE
add OpenClaw - self-hosted AI assistant platform

### DIFF
--- a/software/openclaw.yml
+++ b/software/openclaw.yml
@@ -1,0 +1,12 @@
+name: OpenClaw
+website_url: https://openclawhardware.dev
+source_code_url: https://github.com/openclaw/openclaw
+description: AI assistant platform that runs on dedicated hardware (NVIDIA Jetson). Supports Telegram, WhatsApp, Discord, browser automation, cron jobs, and multi-agent workflows. Privacy-first with all data staying local.
+licenses:
+  - MIT
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Automation
+platforms:
+  - Nodejs
+demo_url: https://openclawhardware.dev


### PR DESCRIPTION
OpenClaw is an open-source AI assistant platform designed to run on dedicated hardware like NVIDIA Jetson. It supports multiple messaging platforms (Telegram, WhatsApp, Discord), browser automation, cron scheduling, and multi-agent workflows.

- **Website:** https://openclawhardware.dev
- **Source:** https://github.com/openclaw/openclaw (184K+ stars)
- **License:** MIT
- **Tags:** Generative AI, Automation

Key features: privacy-first (all data local), multi-platform messaging, browser automation, cron jobs, runs on 15W edge hardware.