### PR TITLE
Add OneUptime

### DIFF
--- a/software/oneuptime.yml
+++ b/software/oneuptime.yml
@@ -1,0 +1,12 @@
+name: OneUptime
+website_url: https://oneuptime.com/
+description: Complete observability platform with monitoring, status pages, incident management, on-call scheduling, logs, traces, and metrics.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+  - K8S
+tags:
+  - Status / Uptime pages
+source_code_url: https://github.com/OneUptime/oneuptime
+demo_url: https://oneuptime.com/


### PR DESCRIPTION
Adding [OneUptime](https://oneuptime.com/) to the **Status / Uptime pages** category.

OneUptime is a complete open-source observability platform with monitoring, status pages, incident management, on-call scheduling, logs, traces, and metrics.

- **Website:** https://oneuptime.com
- **Source Code:** https://github.com/OneUptime/oneuptime
- **License:** Apache-2.0
- **Platforms:** Docker, Kubernetes
- **GitHub Stars:** 4,800+
- **Contributors:** 99+
- **First release:** 2019

- [x] Submit one item per issue.
- [x] Searched for relevant issues or PRs, including closed ones.
- [x] Not listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io.
- [x] Actively maintained.
- [x] First released more than 4 months ago.
- [x] Has working installation instructions.