### PR TITLE
Add RustChain - Proof-of-Antiquity blockchain node

### DIFF
--- a/software/rustchain.yml
+++ b/software/rustchain.yml
@@ -1,0 +1,11 @@
+name: "RustChain"
+website_url: "https://rustchain.org"
+source_code_url: "https://github.com/Scottcjn/Rustchain"
+description: "Proof-of-Antiquity blockchain node with hardware fingerprint attestation, where vintage hardware earns higher mining rewards."
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+tags:
+  - Money, Budgeting & Management
+demo_url: "https://rustchain.org"


### PR DESCRIPTION
## RustChain

RustChain is a Proof-of-Antiquity blockchain node where vintage hardware (PowerPC G4/G5, Pentium 4, etc.) earns higher mining rewards through hardware fingerprint attestation. It features a built-in block explorer, REST API, epoch-based reward settlement, and Ed25519 wallet security.

- **Website**: https://rustchain.org
- **Source**: https://github.com/Scottcjn/Rustchain
- **License**: Apache-2.0
- **Platform**: Python
- **Demo**: https://rustchain.org (block explorer)

The software has been released and is actively maintained with tagged releases.

### Checklist

- [x] Submit one item per issue/pull request
- [x] Searched for relevant issues or PRs, including closed ones
- [x] Not already listed at awesome-sysadmin, staticgen.com, or dbdb.io
- [x] Software project is actively maintained
- [x] Software project has working installation instructions
- [x] Any software project you are adding was first released more than 4 months ago (repo created April 2025, first release January 2026)