### PR TITLE
add Agent Analytics

### DIFF
--- a/software/agent-analytics.yml
+++ b/software/agent-analytics.yml
@@ -1,0 +1,13 @@
+name: "Agent Analytics"
+website_url: "https://agentanalytics.sh"
+source_code_url: "https://github.com/dannyshmueli/agentanalytics"
+description: "API-first website analytics built for the AI agent era. Your coding agent queries your analytics via CLI or API — no dashboard needed. Privacy-focused, no PII."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Cloudflare
+  - Docker
+tags:
+  - Analytics
+  - Personal Dashboards


### PR DESCRIPTION
Adding [Agent Analytics](https://agentanalytics.sh) — API-first website analytics built for the AI agent era.

Your AI coding agent queries your analytics via CLI or API instead of opening a dashboard. Privacy-focused (no PII, no cookies), open source, runs on Cloudflare edge.

- **Source:** https://github.com/dannyshmueli/agentanalytics
- **License:** MIT
- **Platforms:** Node.js, Cloudflare Workers, Docker