### PR TITLE
Add CrowdSec Blocklist Import

### DIFF
--- a/software/crowdsec-blocklist-import.yml
+++ b/software/crowdsec-blocklist-import.yml
@@ -1,0 +1,11 @@
+name: CrowdSec Blocklist Import
+website_url: https://github.com/wolffcatskyy/crowdsec-blocklist-import
+description: Import 120k+ IPs from 36 free threat intelligence feeds into CrowdSec for enhanced network protection.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Python
+tags:
+  - Network Utilities
+source_code_url: https://github.com/wolffcatskyy/crowdsec-blocklist-import


### PR DESCRIPTION
## Software Details

**Name:** CrowdSec Blocklist Import  
**URL:** https://github.com/wolffcatskyy/crowdsec-blocklist-import  
**License:** MIT  
**Platforms:** Docker, Python

## Description

Import 120k+ IPs from 36 free threat intelligence feeds into CrowdSec for enhanced network protection (10-20x more blocks for CrowdSec bouncers).

## Checklist

- [x] Submit one item per issue
- [x] Searched for relevant issues/PRs
- [x] Not listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io
- [x] Software is actively maintained
- [ ] First released more than 4 months ago (first release: Feb 1, 2026)
- [x] Working installation instructions

## Note

The first release was February 1, 2026. I understand this is less than 4 months old per your guidelines. Please feel free to close this PR and tag it for resubmission when the project reaches the 4-month maturity threshold (around June 2026).

The project has gained 167 stars in its first two weeks, demonstrating community interest. I'm happy to resubmit when it meets the maturity requirements.