### PR TITLE
Add Screenpipe

### DIFF
--- a/software/screenpipe.yml
+++ b/software/screenpipe.yml
@@ -1,0 +1,11 @@
+name: Screenpipe
+website_url: https://screenpi.pe/
+source_code_url: https://github.com/screenpipe/screenpipe
+description: 24/7 local screen and audio recording with AI-powered search. Find anything you've seen, said, or heard using natural language queries. All data stays on your machine.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Knowledge Management Tools


### PR DESCRIPTION
adds [screenpipe](https://screenpi.pe/) to knowledge management tools.

screenpipe records your screen and audio 24/7 locally, then lets you search everything using natural language. all data stays on your machine.

- 25k+ github stars, MIT licensed
- built with rust, runs as docker or native binary
- [source code](https://github.com/screenpipe/screenpipe)