### PR TITLE
Add Snippet Share

### DIFF
--- a/software/snippet-share.yml
+++ b/software/snippet-share.yml
@@ -1,0 +1,12 @@
+name: Snippet Share
+website_url: https://snippet-share.com
+description: Zero-knowledge code snippet sharing with client-side AES-256-GCM encryption, password protection, and burn-after-reading (alternative to Pastebin, PrivateBin).
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Cloudflare
+tags:
+  - Pastebins
+source_code_url: https://github.com/abdihashii/code-snippet-tool
+demo_url: https://snippet-share.com


### PR DESCRIPTION
### Software addition

- [x] This is one item per issue
- [x] The software is not already listed elsewhere
- [x] The project was first released more than 4 months ago (May 2025)
- [x] Working installation/deployment instructions available

**Entry file:** `software/snippet-share.yml`

Zero-knowledge encrypted code snippet sharing. All encryption/decryption happens client-side using the Web Crypto API (AES-256-GCM). The server only stores encrypted blobs and can never read plaintext content.

Source: https://github.com/abdihashii/code-snippet-tool
Live: https://snippet-share.com
License: MIT