### PR TITLE
Add SecureShare

### DIFF
--- a/software/secureshare.yml
+++ b/software/secureshare.yml
@@ -1,0 +1,11 @@
+name: SecureShare
+website_url: https://secureshare-relay.duckdns.org
+source_code_url: https://github.com/artmarchenko/SecureShare
+description: End-to-end encrypted file transfer between devices via a zero-knowledge WebSocket relay. No registration, no cloud storage.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - File Transfer - Single-click & Drag-n-drop Upload


### PR DESCRIPTION
## Add SecureShare

**SecureShare** is a desktop app (Windows/Linux) + Docker relay server for direct E2E encrypted file transfers between devices.

### Details

- **Website:** https://secureshare-relay.duckdns.org
- **Source Code:** https://github.com/artmarchenko/SecureShare
- **License:** MIT
- **Platforms:** Python, Docker
- **Category:** File Transfer - Single-click & Drag-n-drop Upload

### Key features

- End-to-end encryption: X25519 + AES-256-GCM
- Zero-knowledge relay server (never sees file contents or metadata)
- No registration or accounts required
- Self-hostable via Docker (relay + Caddy reverse proxy)
- Auto-reconnect and transfer resume on connection loss
- Active development (v3.4.0, Feb 2026)

### Checklist

- [x] One item per issue
- [x] Searched for relevant issues/PRs
- [x] Not listed in awesome-sysadmin, staticgen.com, etc.
- [x] Actively maintained
- [x] First released more than 4 months ago
- [x] Working installation instructions