### PR TITLE
add BLE Scale Sync

### DIFF
--- a/software/ble-scale-sync.yml
+++ b/software/ble-scale-sync.yml
@@ -3,7 +3,7 @@ website_url: https://blescalesync.dev
 source_code_url: https://github.com/KristianP26/ble-scale-sync
 description: Reads body composition data from 23 BLE smart scales and exports to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, webhooks, push notifications and local files.
 licenses:
-  - GPL-3.0-only
+  - GPL-3.0
 platforms:
   - Nodejs
   - Docker


### PR DESCRIPTION
## Software

**Name:** BLE Scale Sync
**Website:** https://blescalesync.dev
**Source:** https://github.com/KristianP26/ble-scale-sync
**License:** GPL-3.0

## Description

Cross-platform CLI tool that reads body composition data (weight, body fat, muscle mass, BMR, and more) from 23 BLE smart scales and exports to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, webhooks, push notifications (ntfy), and local files (CSV/JSONL).

Runs headless on a Raspberry Pi or any machine with Bluetooth. Docker images available for Linux (amd64, arm64, armv7).

## Tags

- Internet of Things (IoT)
- Health and Fitness

## Checklist

- [x] The software has a free/open-source license
- [x] The software can be self-hosted
- [x] The software is ready for end-users
- [x] The software does not depend on proprietary cloud services
- [x] The software has working installation instructions
- [x] No duplicate entry exists in the list