### PR TITLE
Add OpenCodex - native iOS client for Claude/Codex AI with self-hosted backend

### DIFF
--- a/software/opencodex.yml
+++ b/software/opencodex.yml
@@ -1,0 +1,12 @@
+# OpenCodex - native iOS AI coding assistant with self-hosted backend
+name: OpenCodex
+website_url: https://github.com/mjmkk/opencodex
+source_code_url: https://github.com/mjmkk/opencodex
+description: Native iOS client + self-hosted Node.js backend to run Claude/Codex AI from your iPhone — real-time chat, remote terminal (PTY/WebSocket), file browser, and command approval.
+licenses:
+  - Apache-2.0
+platforms:
+  - Nodejs
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Software Development - IDE & Tools


### PR DESCRIPTION
## Description
Adding [OpenCodex](https://github.com/mjmkk/opencodex) — a native iOS app + self-hosted Node.js backend that lets you run Claude/Codex AI from your iPhone.

## Why it fits this list
OpenCodex has a **self-hosted backend component** (Node.js 22 server) that users deploy on their own infrastructure. The iOS client connects to this self-hosted backend, which:
- Manages WebSocket connections for real-time terminal (PTY)
- Handles SSE streaming for AI responses from Claude/Codex
- Provides file system access APIs
- Stores session history in SQLite

## Checklist
- [x] The project is open source (Apache 2.0)
- [x] The project is actively maintained
- [x] The project has a self-hosted backend component
- [x] YAML file follows the required format
- [x] Using kebab-case filename: `opencodex.yml`
- [x] Description is under 250 characters

## Additional Notes
- Platforms: `Nodejs` (the self-hosted backend)
- Tags: `Generative Artificial Intelligence (GenAI)`, `Software Development - IDE & Tools`
- License: Apache-2.0