### PR TITLE
Add OpenHabitTracker

### DIFF
--- a/software/openhabittracker.yml
+++ b/software/openhabittracker.yml
@@ -1,0 +1,13 @@
+name: OpenHabitTracker
+website_url: https://openhabittracker.net
+source_code_url: https://github.com/Jinjinov/OpenHabitTracker
+description: Track habits, tasks and notes with time tracking, calendar view and completion statistics.
+licenses:
+  - GPL-3.0
+platforms:
+  - C#
+  - Docker
+tags:
+  - Time Tracking
+  - Task Management & To-do Lists
+demo_url: https://pwa.openhabittracker.net


### PR DESCRIPTION
OpenHabitTracker is a free, open source habit tracker with time tracking, calendar view and completion statistics. Self-hostable via Docker. GPL-3.0. https://openhabittracker.net