### PR TITLE
Add FCaptcha

### DIFF
--- a/software/fcaptcha.yml
+++ b/software/fcaptcha.yml
@@ -1,0 +1,14 @@
+name: FCaptcha
+description: CAPTCHA that detects bots, vision AI agents, and headless browsers through behavioral analysis and SHA-256 proof of work.
+website_url: https://webdecoy.com/product/fcaptcha/
+source_code_url: https://github.com/WebDecoy/FCaptcha
+demo_url: https://webdecoy.com/product/fcaptcha-demo/
+licenses:
+  - MIT
+platforms:
+  - Go
+  - Nodejs
+  - Python
+  - Docker
+tags:
+  - Miscellaneous


### PR DESCRIPTION
## Summary
Adds FCaptcha, a CAPTCHA system for detecting bots, vision AI agents, and headless browsers through behavioral analysis and SHA-256 proof of work.

## Checklist
- [x] Self-hostable (Docker one-liner deployment)
- [x] Open source (MIT)
- [x] Actively maintained
- [x] Working demo available: https://webdecoy.com/product/fcaptcha-demo/
- [x] Docker deployment supported

## Links
- GitHub: https://github.com/WebDecoy/FCaptcha
- Website: https://webdecoy.com/product/fcaptcha/
- Demo: https://webdecoy.com/product/fcaptcha-demo/

Similar to existing entry: mosparo