### PR TITLE
Add Char

### DIFF
--- a/software/char.yml
+++ b/software/char.yml
@@ -1,0 +1,11 @@
+name: Char
+website_url: https://char.com
+description: AI notepad for meetings with flexible AI stack and on-device storage (Open-source alternative to Otter.ai, Granola, Fireflies).
+licenses:
+  - GPL-3.0
+platforms:
+  - Rust
+  - Nodejs
+tags:
+  - Note-taking & Editors
+source_code_url: https://github.com/fastrepl/char


### PR DESCRIPTION
Added [Char](https://char.com) — AI notepad for meetings with flexible AI stack and on-device storage (open-source alternative to Otter.ai, Granola, Fireflies).

- Website: https://char.com
- Source: https://github.com/fastrepl/char
- License: GPL-3.0
- Platforms: Rust, Node.js (Tauri desktop app)
- Tag: Note-taking & Editors
- Repo created: December 2024 (previously named hyprnote, rebranded to Char)

>