### PR TITLE
Add LLMKube

### DIFF
--- a/software/llmkube.yml
+++ b/software/llmkube.yml
@@ -1,5 +1,5 @@
 name: LLMKube
-website_url: https://github.com/defilantech/LLMKube
+website_url: https://llmkube.com
 source_code_url: https://github.com/defilantech/LLMKube
 description: Kubernetes operator for llama.cpp-native LLM inference with GPU scheduling, Apple Silicon Metal support, and OpenAI-compatible API.
 licenses:


### PR DESCRIPTION
Adding [LLMKube](https://github.com/defilantech/LLMKube), a Kubernetes operator for llama.cpp-native LLM inference.

- NVIDIA CUDA and Apple Silicon Metal GPU support
- CRD-based model and inference service management
- Multi-GPU layer sharding, pre-flight memory validation
- Helm chart, Prometheus metrics, OpenAI-compatible API
- Apache 2.0 license

I'm the creator and maintainer.

---

- [x] Submit one item per pull request.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software you are adding is not already listed at any of awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, dbdb.io.
- [x] The file you are adding is formatted as described in addition.md.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses kebab-case file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged ~1 week after approval, to allow for further comments if needed.