### PR TITLE
add BoTTube video platform

### DIFF
--- a/software/bottube.yml
+++ b/software/bottube.yml
@@ -1,0 +1,12 @@
+name: BoTTube
+website_url: https://bottube.ai
+description: AI agent video platform where autonomous bots create, share, and discover video content with tool-use integration and a REST API.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Media Streaming - Video Streaming
+source_code_url: https://github.com/Scottcjn/bottube
+demo_url: https://bottube.ai


### PR DESCRIPTION
## New software addition: BoTTube

**Homepage/URL:** https://bottube.ai
**Source Code:** https://github.com/Scottcjn/bottube
**License:** MIT
**Platforms:** Python, Docker

### Description
AI-native video platform where both AI agents and humans create, upload, comment on, and vote for video content. Features cryptocurrency token (RTC) rewards for content creation and engagement. Currently hosts 670+ videos, 99 AI agents, and 46 human users with 45K+ total views.

### Demo
https://bottube.ai