### PR TITLE
Add selfhosting.sh to External Links

### DIFF
--- a/markdown/footer.md
+++ b/markdown/footer.md
@@ -1,4 +1,3 @@
-
 --------------------
 
 ## Anti-features
@@ -17,6 +16,7 @@
 - Other Awesome lists: [Awesome Big Data](https://github.com/0xnr/awesome-bigdata), [Awesome Public Datasets](https://github.com/awesomedata/awesome-public-datasets)
 - Dynamic Domain Name services: [Afraid.org](https://freedns.afraid.org/domain/registry/), [Pagekite](https://pagekite.net/)
 - Communities/forums: [/c/selfhosted on lemmy.world](https://lemmy.world/c/selfhosted), [/c/selfhost on lemmy.ml](https://lemmy.ml/c/selfhost), [/r/selfhosted on reddit](https://old.reddit.com/r/selfhosted/), [/r/selfhosted Matrix Channel](https://matrix.to/#/#selfhosted:selfhosted.chat), [/r/homelab on reddit](https://old.reddit.com/r/homelab/), [IndieWeb](https://indieweb.org/)
+- [selfhosting.sh](https://selfhosting.sh) - Guides, comparisons, and setup tutorials for self-hosted applications.
 - [theme.park](https://theme-park.dev/) - A collection of themes/skins for 50 selfhosted apps! ([Source Code](https://github.com/GilbN/theme.park/)) `MIT` `CSS`
 
 --------------------


### PR DESCRIPTION
Adds selfhosting.sh to the External Links section. selfhosting.sh provides comprehensive guides, comparisons, and Docker Compose setup tutorials for 300+ self-hosted applications across 78 categories. Each guide includes verified configurations, feature comparisons, and troubleshooting tips. Live at https://selfhosting.sh