### PR TITLE
Add Satoshi API

### DIFF
--- a/software/satoshi-api.yml
+++ b/software/satoshi-api.yml
@@ -1,0 +1,11 @@
+name: Satoshi API
+website_url: https://bitcoinsapi.com
+description: REST API for Bitcoin Core nodes. Turns your node into a developer-friendly data service with fee recommendations, mempool analysis, and real-time streams.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+tags:
+  - Money, Budgeting & Management
+source_code_url: https://github.com/Bortlesboat/bitcoin-api
+demo_url: https://bitcoinsapi.com/docs


### PR DESCRIPTION
## Summary
Self-hosted REST API that wraps Bitcoin Core's JSON-RPC in 50 developer-friendly endpoints. Fee recommendations, mempool congestion analysis, real-time SSE streams, block/transaction inspection.

- **Website:** https://bitcoinsapi.com
- **Source:** https://github.com/Bortlesboat/bitcoin-api
- **Demo:** https://bitcoinsapi.com/docs (interactive Swagger)
- **Install:** `pip install satoshi-api`
- **License:** Apache-2.0
- **Language:** Python

Runs on the same machine as your Bitcoin node. No external dependencies, no third-party data sharing.