### PR TITLE
Add OpenClaw Easy

### DIFF
--- a/software/openclaw-easy.yml
+++ b/software/openclaw-easy.yml
@@ -1,6 +1,6 @@
-name: OpenClaw
+name: OpenClaw Easy
 website_url: https://openclaw-easy.com
-description: AI assistant gateway that connects LLMs (ChatGPT, Claude, Ollama) to WhatsApp, Telegram, Slack, and Discord. Supports local models via Ollama for fully offline operation.
+description: Free desktop app that connects LLMs (ChatGPT, Claude, Ollama) to WhatsApp, Telegram, Slack, and Discord. Built on top of the open-source OpenClaw project.
 licenses:
   - MIT
 platforms:


### PR DESCRIPTION
## Add OpenClaw Easy

- **Website:** https://openclaw-easy.com
- **Source Code:** https://github.com/openclaw/openclaw
- **License:** MIT
- **Category:** Communication - Custom Communication Systems

OpenClaw Easy is a free desktop app that connects LLMs (ChatGPT, Claude, Ollama) to messaging platforms like WhatsApp, Telegram, Slack, and Discord. Built on top of the open-source OpenClaw project. Supports fully offline operation via Ollama local models.

Marked `depends_3rdparty: true` since cloud AI providers (OpenAI, Anthropic) are external services, though Ollama provides a fully self-contained alternative.