### PR TITLE
Add Pharos AI

### DIFF
--- a/software/pharos-ai.yml
+++ b/software/pharos-ai.yml
@@ -1,0 +1,12 @@
+name: Pharos AI
+website_url: https://conflicts.app
+description: Real-time intelligence dashboard for geopolitical conflict tracking, aggregating 30+ OSINT feeds with interactive geospatial visualization, actor dossiers, event timelines, and daily intelligence briefs.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Maps and Global Positioning System (GPS)
+source_code_url: https://github.com/Juliusolsson05/pharos-ai
+demo_url: https://conflicts.app


### PR DESCRIPTION
Pharos AI is an open-source real-time intelligence dashboard for geopolitical conflict tracking.

- Live: https://conflicts.app
- Repo: https://github.com/Juliusolsson05/pharos-ai
- License: AGPL-3.0-only
- Stack: Next.js 16, React 19, PostgreSQL, DeckGL, MapLibre
- Self-hostable via Docker

It aggregates 30+ OSINT feeds (Reuters, AP, Press TV, TASS, etc.), provides interactive geospatial visualization, actor dossiers, event timelines, and daily intelligence briefs.