### PR TITLE
add MiniClaw — self-hosted personal AI OS for Mac

### DIFF
--- a/software/miniclaw.yml
+++ b/software/miniclaw.yml
@@ -1,0 +1,12 @@
+name: MiniClaw
+website_url: https://miniclaw.bot
+source_code_url: https://github.com/augmentedmike/miniclaw-os
+description: Personal AI agent OS for Mac — personality, memory, plugins, cron automation, email, SEO tools, and a kanban project board, all running on your own hardware.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Automation
+


### PR DESCRIPTION
## Add MiniClaw

[MiniClaw](https://github.com/augmentedmike/miniclaw-os) is a self-hosted personal AI agent OS for Mac, built on top of [OpenClaw](https://github.com/openclaw/openclaw).

**Features:**
- Persistent personality and long-term memory
- Plugin ecosystem: kanban board, email client, SEO rank tracker, cron automation, image designer
- Runs as a daemon service (launchd) on macOS
- Web UI for kanban project management
- Self-hosted — all data stays on your own hardware
- Open source, MIT license

**Category:** Generative Artificial Intelligence (GenAI), Automation

**Links:**
- GitHub: https://github.com/augmentedmike/miniclaw-os (MIT)
- Website: https://miniclaw.bot

Checklist:
- [x] Added YAML file at `software/miniclaw.yml`
- [x] MIT license
- [x] Active development (multiple commits per month)
- [x] Self-hostable on own hardware