### PR TITLE
Add mini-agent

### DIFF
--- a/software/mini-agent.yml
+++ b/software/mini-agent.yml
@@ -1,0 +1,10 @@
+name: mini-agent
+website_url: https://github.com/miles990/mini-agent
+description: Perception-driven personal AI agent framework. Shell scripts define what the agent can see, Claude decides what to do. File-based memory (Markdown + JSON Lines), no database.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Automation
+source_code_url: https://github.com/miles990/mini-agent


### PR DESCRIPTION
## Addition

**Name:** mini-agent  
**Website:** https://github.com/miles990/mini-agent  
**Description:** Perception-driven personal AI agent framework. Shell scripts define what the agent can see, Claude decides what to do. File-based memory (Markdown + JSON Lines), no database.  
**License:** MIT  
**Platform:** Node.js / TypeScript  
**Category:** Automation  

### Why this belongs here

mini-agent is a self-hosted personal AI agent that runs on your own machine. Unlike goal-driven agent frameworks, it's **perception-driven** — shell scripts define what it can observe (Docker containers, Git repos, Chrome tabs, etc.) and an LLM decides whether and how to act.

- In production with 1500+ autonomous cycles
- No database, no embeddings — just Markdown files and shell scripts
- Transparent: every action has an audit trail via git history
- MIT licensed