### PR TITLE
Add Databasement to Database Management

### DIFF
--- a/software/databasement.yml
+++ b/software/databasement.yml
@@ -1,0 +1,12 @@
+name: Databasement
+website_url: https://github.com/David-Crty/databasement
+source_code_url: https://github.com/David-Crty/databasement
+description: Database backup management tool supporting MySQL, MariaDB, PostgreSQL, MongoDB, SQLite, and Redis with scheduling, multiple storage backends, and cross-server restore.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - PHP
+tags:
+  - Database Management
+demo_url: https://databasement-demo.crty.dev/


### PR DESCRIPTION
## Summary
- Adds [Databasement](https://github.com/David-Crty/databasement) — a self-hosted database backup management tool with a web UI
- Supports MySQL, MariaDB, PostgreSQL, MongoDB, SQLite, and Redis/Valkey
- Features: automated scheduled backups, multiple storage backends (local, S3, SFTP, FTP), cross-server restore, SSH tunnels, failure notifications, and multi-user support
- MIT licensed, Docker-based, 276+ stars, actively maintained
- [Live demo](https://databasement-demo.crty.dev/)

## Checklist
- [x] Software is Free/Open Source (MIT)
- [x] Has tagged releases
- [x] Actively maintained
- [x] Description is under 250 characters
- [x] One item per PR