### PR TITLE
Update Nirvati source code URL

### DIFF
--- a/software/nirvati.yml
+++ b/software/nirvati.yml
@@ -1,6 +1,6 @@
 name: "Nirvati"
 website_url: "https://nirvati.org"
-source_code_url: "https://gitlab.com/nirvati-ug/nirvati"
+source_code_url: "https://gitlab.com/nirvati-ug/nirvati/backend"
 description: "Easily 1-click spin up popular self-hosted apps from a convenient web interface."
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
Point to the backend repository URL instead of the gitlab project subgroup

- ref. https://github.com/nodiscc/hecat/pull/152

/cc @Rabenherz112 