### PR TITLE
add Visura API

### DIFF
--- a/software/visura-api.yml
+++ b/software/visura-api.yml
@@ -1,0 +1,11 @@
+name: Visura API
+website_url: https://github.com/zornade/visura-api
+description: REST API for automated Italian cadastral property record extraction (visure catastali) from the SISTER portal, using Playwright for browser automation with SPID authentication.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Miscellaneous
+source_code_url: https://github.com/zornade/visura-api


### PR DESCRIPTION
## Add Visura API

**Name:** Visura API
**Website/Source:** https://github.com/zornade/visura-api
**License:** AGPL-3.0
**Platforms:** Python, Docker
**Tag:** Miscellaneous

### Description

REST API service for automated Italian cadastral property record extraction (*visure catastali*) from the Agenzia delle Entrate SISTER portal. Built with FastAPI and Playwright for headless browser automation with SPID authentication.

### Features

- Automated SPID login flow via Playwright
- Cadastral lookups by subject (persona fisica/giuridica) or property (immobile)
- Province/municipality selection with configurable parameters
- Full Docker support with docker-compose
- Debug HTML page snapshots for troubleshooting

### Requirements checklist

- [x] Self-hosted software
- [x] Free/Open Source (AGPL-3.0)
- [x] Has a source code repository
- [x] Has a working release (v0.1.0)
