### PR TITLE
tools: update actions/checkout version

### DIFF
--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -17,6 +17,6 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make install
       - run: make url_check

--- a/.github/workflows/check-unmaintained-projects.yml
+++ b/.github/workflows/check-unmaintained-projects.yml
@@ -17,6 +17,6 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make install
       - run: make awesome_lint_strict

--- a/.github/workflows/daily-update-metadata.yml
+++ b/.github/workflows/daily-update-metadata.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make install
       - run: make update_metadata
       - name: commit and push changes

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
   syntax-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make install
       - run: make awesome_lint
       - run: make export_markdown


### PR DESCRIPTION
- Fixes current deprecation warning we have in our actions by upgrading `actions/checkout` to v6
- Quick check in [actions/checkout](https://github.com/actions/checkout) doesn't seem to show any breaking changes at least
<img width="2180" height="250" alt="image" src="https://github.com/user-attachments/assets/774c0768-75f1-46b1-a671-1ca075649b09" />
