### PR TITLE
Add JARVIS - self-hosted AI assistant with sandboxed tool execution and visual workflow studio

### DIFF
--- a/software/jarvis.yml
+++ b/software/jarvis.yml
@@ -1,0 +1,11 @@
+name: "JARVIS"
+website_url: "https://github.com/hyhmrright/JARVIS"
+source_code_url: "https://github.com/hyhmrright/JARVIS"
+description: "AI assistant platform with LangGraph ReAct agent, RAG knowledge base, sandboxed tool execution, visual workflow studio, multi-tenant workspaces, and full-stack observability."
+licenses:
+  - "MIT"
+platforms:
+  - "Python"
+  - "Docker"
+tags:
+  - "Generative Artificial Intelligence (GenAI)"


### PR DESCRIPTION
## JARVIS

JARVIS is an actively maintained self-hosted AI assistant platform.

**Key differentiators vs existing GenAI entries:**
- **Sandboxed execution** — shell/browser tools run in ephemeral Docker containers isolated from the host filesystem
- **LangGraph ReAct agent** with 8 built-in tools (web search, code exec, file I/O, shell, browser, RAG, datetime, canvas)
- **Visual Workflow Studio** — node-based editor (LLM Node / Tool Node / Condition) that compiles to LangGraph at runtime
- **Multi-tenant** — Organizations → Workspaces → Members hierarchy with audit logs
- **One `docker compose up` deploy** with full observability stack (Traefik + Grafana + Loki + Prometheus)

**Links:**
- Source: https://github.com/hyhmrright/JARVIS
- License: MIT
- Last commit: March 2026 (actively maintained)
