### PR TITLE
Add OneSearch

### DIFF
--- a/software/onesearch.yml
+++ b/software/onesearch.yml
@@ -1,0 +1,11 @@
+name: OneSearch
+website_url: https://onesearch.readthedocs.io
+description: Self-hosted search appliance for homelabs. Full-text search across local directories, NAS shares, and drives via a web UI, with scheduled indexing and document preview.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Search Engines
+source_code_url: https://github.com/demigodmode/OneSearch


### PR DESCRIPTION
Self-hosted search appliance for homelabs. Indexes local directories, NAS shares, and drives with full-text search, scheduled indexing, and document preview. Runs in Docker Compose, no cloud dependencies.

- License: AGPL-3.0
- Source: https://github.com/demigodmode/OneSearch
- Docs: https://onesearch.readthedocs.io