### PR TITLE
fix: issue template wrong capitalization of deb

### DIFF
--- a/.github/ISSUE_TEMPLATE/addition.md
+++ b/.github/ISSUE_TEMPLATE/addition.md
@@ -32,7 +32,7 @@ platforms:
   - Python
   - PHP
   - Nodejs
-  - Deb
+  - deb
   - Docker
 # list of tags (categories), see https://github.com/awesome-selfhosted/awesome-selfhosted-data/tree/master/tags for the full list of tags
 tags:


### PR DESCRIPTION
The issue template as a capitalized `Deb` listed, however the tag is actually lowercase `deb`, which if you copy paste the platform from the issue template causes a CI error