### PR TITLE
add tunelo

### DIFF
--- a/software/tunelo.yml
+++ b/software/tunelo.yml
@@ -1,0 +1,11 @@
+name: tunelo
+website_url: https://tunelo.net
+description: Expose localhost to the internet via QUIC tunnel. Single binary with built-in file server and web explorer for code, PDF, video, audio, and CSV preview.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Proxy
+source_code_url: https://github.com/jiweiyuan/tunelo


### PR DESCRIPTION
**[tunelo](https://tunelo.net)** — Expose localhost to the internet via QUIC tunnel.

- Single binary (Rust): `tunelo http 3000`, `tunelo serve .`, `tunelo relay`
- QUIC transport, zero-copy relay, auto-reconnect
- Built-in file server with web explorer (code, PDF, video, audio, CSV)
- Self-hostable relay, Docker support, MIT License

Source: https://github.com/jiweiyuan/tunelo