### PR TITLE
Add Ups status page platform

### DIFF
--- a/software/ups.yml
+++ b/software/ups.yml
@@ -1,0 +1,12 @@
+name: "Ups"
+website_url: "https://ups.dev"
+source_code_url: "https://github.com/codenamev/ups"
+description: "Status page and incident management platform built with Rails 8 and SQLite."
+licenses:
+  - AGPL-3.0
+platforms:
+  - Ruby
+  - Docker
+tags:
+  - Status / Uptime pages
+demo_url: "https://ups.dev/ups-dev"


### PR DESCRIPTION
## Add Ups

- **Name:** Ups
- **Website:** https://ups.dev
- **Source:** https://github.com/codenamev/ups
- **License:** AGPL-3.0
- **Platforms:** Ruby, Docker
- **Category:** Status / Uptime pages
- **Demo:** https://ups.dev/ups-dev

Status page and incident management platform built with Rails 8 and SQLite. Single Docker container, no external database required.

- [x] One item per issue
- [x] Searched for existing issues/PRs
- [x] Software is Free/Open Source
- [x] Source code is publicly available
- [x] Software is actively maintained