### PR TITLE
add Vendel

### DIFF
--- a/software/vendel.yml
+++ b/software/vendel.yml
@@ -1,0 +1,12 @@
+name: Vendel
+website_url: https://vendel.cc
+description: SMS gateway platform for sending messages using registered Android devices or modems, with quota management, webhooks, and API key authentication.
+licenses:
+  - MIT
+platforms:
+  - Go
+  - Docker
+tags:
+  - Communication - Custom Communication Systems
+source_code_url: https://github.com/JimScope/vendel
+demo_url: https://app.vendel.cc


### PR DESCRIPTION
## Add Vendel

[Vendel](https://vendel.cc) is an SMS gateway platform that turns registered Android devices or modems into SMS gateways. It features quota management, webhooks with HMAC-SHA256 signed payloads, multi-user support, and API key authentication.

**Category:** Communication - Custom Communication Systems

**Tech:** Go (PocketBase) + Docker

**License:** MIT

**Demo:** https://app.vendel.cc

**Source:** https://github.com/JimScope/vendel