### PR TITLE
Add Betula

### DIFF
--- a/software/betula.yml
+++ b/software/betula.yml
@@ -1,0 +1,13 @@
+name: "Betula"
+website_url: "https://betula.mycorrhiza.wiki"
+source_code_url: "https://codeberg.org/bouncepaw/betula"
+description: "A self-hosted federated bookmark manager."
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Javascript
+  - C
+tags:
+  - Bookmarks and Link Sharing
+depends_3rdparty: false

--- a/software/betula.yml
+++ b/software/betula.yml
@@ -7,7 +7,6 @@ licenses:
 platforms:
   - Go
   - Javascript
-  - C
 tags:
   - Bookmarks and Link Sharing
 depends_3rdparty: false

--- a/software/betula.yml
+++ b/software/betula.yml
@@ -1,7 +1,7 @@
 name: "Betula"
 website_url: "https://betula.mycorrhiza.wiki"
 source_code_url: "https://codeberg.org/bouncepaw/betula"
-description: "A self-hosted federated bookmark manager."
+description: "Single-user federated bookmark manager with Fediverse support and archives."
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/betula.yml
+++ b/software/betula.yml
@@ -6,6 +6,5 @@ licenses:
   - AGPL-3.0
 platforms:
   - Go
-  - Javascript
 tags:
   - Bookmarks and Link Sharing

--- a/software/betula.yml
+++ b/software/betula.yml
@@ -1,5 +1,5 @@
 name: "Betula"
-website_url: "https://betula.mycorrhiza.wiki"
+website_url: "https://joinbetula.org"
 source_code_url: "https://codeberg.org/bouncepaw/betula"
 description: "Single-user federated bookmark manager with Fediverse support and archives."
 licenses:

--- a/software/betula.yml
+++ b/software/betula.yml
@@ -9,4 +9,3 @@ platforms:
   - Javascript
 tags:
   - Bookmarks and Link Sharing
-depends_3rdparty: false


### PR DESCRIPTION
<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->

Thanks for taking the time to suggest an addition to awesome-selfhosted! 

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged ~1 week after approval, to allow for further comments if needed.
