### PR TITLE
add EmitHQ

### DIFF
--- a/software/emithq.yml
+++ b/software/emithq.yml
@@ -1,0 +1,11 @@
+name: EmitHQ
+website_url: https://emithq.com
+description: Webhook infrastructure platform for sending and receiving webhooks with Standard Webhooks signing, configurable retries, circuit breakers, and a real-time dashboard.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Software Development - API Management
+source_code_url: https://github.com/Not-Another-Ai-Co/EmitHQ


### PR DESCRIPTION
EmitHQ is an open-source (AGPL-3.0) webhook infrastructure platform for sending and receiving webhooks.

- **Website:** https://emithq.com
- **Source:** https://github.com/Not-Another-Ai-Co/EmitHQ
- **License:** AGPL-3.0 (server), MIT (SDKs)
- **Platforms:** Node.js, Docker
- **Tag:** Software Development - API Management (same category as Svix)

Features: Standard Webhooks signing, configurable retries with exponential backoff + jitter, circuit breakers, dead letter queue, real-time dashboard, multi-tenant with PostgreSQL RLS.