### PR TITLE
fix: rename Perplexica to Vane

### DIFF
--- a/software/vane.yml
+++ b/software/vane.yml
@@ -1,6 +1,6 @@
-name: Perplexica
-source_code_url: https://github.com/ItzCrazyKns/Perplexica
-website_url: https://github.com/ItzCrazyKns/Perplexica
+name: Vane
+source_code_url: https://github.com/ItzCrazyKns/Vane
+website_url: https://github.com/ItzCrazyKns/Vane
 description: AI-powered search engine (alternative to Perplexity AI).
 licenses:
   - MIT


### PR DESCRIPTION
- ref: #1 
- ref: #2199
- `repository not found in search results: https://github.com/ItzCrazyKns/Perplexica`
- Project got renamed