### PR TITLE
fix: beelzebub source_code_url

### DIFF
--- a/software/beelzebub.yml
+++ b/software/beelzebub.yml
@@ -1,6 +1,6 @@
 name: beelzebub
 website_url: https://beelzebub-honeypot.com/
-source_code_url: https://github.com/mariocandela/beelzebub
+source_code_url: https://github.com/beelzebub-labs/beelzebub
 description: Honeypot framework designed to provide a highly secure environment for detecting and analyzing cyber attacks.
 licenses:
   - MIT


### PR DESCRIPTION
- ref: #1 
- ref: #2199
- `repository not found in search results: https://github.com/mariocandela/beelzebub`
- Project got moved