### PR TITLE
Add PaperVault to Password Managers

### DIFF
--- a/software/papervault.yml
+++ b/software/papervault.yml
@@ -1,0 +1,12 @@
+name: PaperVault
+website_url: https://papervault.xyz
+description: Store secrets on paper using threshold encryption with Shamir's Secret Sharing (alternative to metal seed plates, paper wallets).
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Password Managers
+source_code_url: https://github.com/boazeb/papervault
+demo_url: https://app.papervault.xyz


### PR DESCRIPTION
## Add PaperVault

**Requesting an age exception.** The repo is less than 4 months old, but the project is production-ready:

- Live and deployed at [app.papervault.xyz](https://app.papervault.xyz)
- Tagged release (v1.0.0) with Docker support
- Client-side only — zero network requests, designed for air-gapped use
- All dependencies self-hosted (no CDN calls)
- MIT licensed

PaperVault fills a niche not currently covered in the list — offline paper-based secret backup with threshold encryption (Shamir's Secret Sharing). There's no equivalent tool listed.

- [x] One item per issue
- [x] No duplicate in the list
- [x] Actively maintained
- [ ] Initial release over 4 months ago *(requesting exception)*
- [x] Working installation instructions