### PR TITLE
Add CloudHop

### DIFF
--- a/software/cloudhop.yml
+++ b/software/cloudhop.yml
@@ -1,0 +1,11 @@
+name: CloudHop
+website_url: https://github.com/ozymandiashh/cloudhop
+description: Visual cloud-to-cloud file transfer tool with live dashboard, pause/resume, presets, and scheduling. Supports 70+ providers via rclone (alternative to MultCloud, Cloudsfer).
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - File Transfer & Synchronization
+source_code_url: https://github.com/ozymandiashh/cloudhop


### PR DESCRIPTION
Adds CloudHop to the File Transfer & Synchronization category.

**CloudHop** is a visual cloud-to-cloud file transfer tool with a live dashboard, pause/resume, presets, and scheduling. Supports 70+ providers via rclone (alternative to MultCloud, Cloudsfer).

- Website/Source: https://github.com/ozymandiashh/cloudhop
- License: MIT
- Platforms: Python, Docker
- Actively maintained
- Has working installation instructions (pip, Homebrew, Docker, native installers)