### PR TITLE
Add crw - web scraper and crawler for AI agents

### DIFF
--- a/software/crw.yml
+++ b/software/crw.yml
@@ -1,0 +1,30 @@
+name: crw
+website_url: https://fastcrw.com
+description: Web scraper and crawler built for AI agents. Single Rust binary, built-in MCP server, Firecrawl-compatible REST API, Docker support.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Automation
+source_code_url: https://github.com/us/crw
+stargazers_count: 13
+updated_at: '2026-03-25'
+archived: false
+current_release:
+  tag: v0.0.13
+  published_at: '2026-03-24'
+commit_history:
+  2025-04: 0
+  2025-05: 0
+  2025-06: 0
+  2025-07: 0
+  2025-08: 0
+  2025-09: 0
+  2025-10: 0
+  2025-11: 0
+  2025-12: 0
+  2026-01: 0
+  2026-02: 0
+  2026-03: 87


### PR DESCRIPTION
Adds [crw](https://github.com/us/crw) to the Automation category.

crw is a self-hosted web scraper and crawler built for AI agents. It ships as a single Rust binary with a built-in MCP server, Firecrawl-compatible REST API, and Docker support.

- Website: https://fastcrw.com
- License: AGPL-3.0
- Platforms: Rust, Docker