### PR TITLE
build: pin actions/checkout to specific SHA commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       url: https://github.com/awesome-selfhosted/awesome-selfhosted
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.ref }}
       - run: make install
@@ -48,7 +48,7 @@ jobs:
       url: https://github.com/awesome-selfhosted/awesome-selfhosted-html
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.ref }}
       - run: make install

--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -17,6 +17,6 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: make install
       - run: make url_check

--- a/.github/workflows/check-unmaintained-projects.yml
+++ b/.github/workflows/check-unmaintained-projects.yml
@@ -17,6 +17,6 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: make install
       - run: make awesome_lint_strict

--- a/.github/workflows/daily-update-metadata.yml
+++ b/.github/workflows/daily-update-metadata.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: make install
       - run: make update_metadata
       - name: commit and push changes

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
   syntax-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: make install
       - run: make awesome_lint
       - run: make export_markdown


### PR DESCRIPTION
- Pin to specific SHA for supply chain security and reproducibility
- build.yml: v4, other workflows: v6
