### PR TITLE
github actions: set environment for update-metadata job

### DIFF
--- a/.github/workflows/daily-update-metadata.yml
+++ b/.github/workflows/daily-update-metadata.yml
@@ -17,6 +17,7 @@ jobs:
   update-metadata:
     if: github.repository == 'awesome-selfhosted/awesome-selfhosted-data'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v6
       - run: make install


### PR DESCRIPTION
- ref: #2209 

You never actually anywhere defined, that the update-metadata job should use the non-default environment. Therefore the current GitLab token was now empty. Since you said you put the token into production (I can't see it, so that's right, right?), here a second attempt of the fix.

