### PR TITLE
Add Admirarr

### DIFF
--- a/software/admirarr.yml
+++ b/software/admirarr.yml
@@ -1,0 +1,11 @@
+name: Admirarr
+website_url: https://github.com/maxtechera/admirarr
+description: Unified CLI for Jellyfin/Plex + *Arr stacks — deploy, configure, diagnose, and operate an entire media server fleet. Single binary with 26 commands, JSON output everywhere, and SKILL.md for AI agent integration.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - Media Management
+  - Automation
+source_code_url: https://github.com/maxtechera/admirarr


### PR DESCRIPTION
# Add Admirarr

## Software information

```yaml
name: Admirarr
website_url: https://github.com/maxtechera/admirarr
description: Unified CLI for Jellyfin/Plex + *Arr stacks — deploy, configure, diagnose, and operate an entire media server fleet. Single binary with 26 commands, JSON output everywhere, and SKILL.md for AI agent integration.
licenses:
  - MIT
platforms:
  - Go
tags:
  - Media Management
  - Automation
source_code_url: https://github.com/maxtechera/admirarr
```

## Checklist

- [x] I have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software I am adding is not already listed on awesome-sysadmin, staticgen.com, staticsitegenerators.net, or dbdb.io.
- [x] The software project I am adding is actively maintained.
- [x] The software project has working installation instructions (`curl -fsSL https://get.admirarr.dev | sh`).

> **Note on age requirement**: Admirarr was first released March 2026. We are aware the 4-month requirement is not yet met and accept this may be held until July 2026. Submitting early to track in the queue.