### PR TITLE
Add Admirarr — unified CLI for *Arr + Jellyfin/Plex stacks

### DIFF
--- a/software/admirarr.yml
+++ b/software/admirarr.yml
@@ -1,0 +1,10 @@
+name: Admirarr
+website_url: https://github.com/maxtechera/admirarr
+description: Unified CLI for Jellyfin/Plex + Radarr + Sonarr + Prowlarr + qBittorrent stacks. One binary, zero dependencies, JSON output. Includes setup, diagnostics, library management, and AI agent integration via SKILL.md.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - Media Management
+source_code_url: https://github.com/maxtechera/admirarr


### PR DESCRIPTION
## Software Details

- **Name:** Admirarr
- **Website:** https://github.com/maxtechera/admirarr
- **Source:** https://github.com/maxtechera/admirarr
- **Description:** Unified CLI for Jellyfin/Plex + Radarr + Sonarr + Prowlarr + qBittorrent stacks. One binary, zero dependencies, JSON output.
- **License:** MIT
- **Platform:** Go
- **Category:** Media Management

## Checklist
- [x] Submit one item per pull request
- [x] Searched for relevant issues or PRs
- [x] Software is actively maintained (first release March 2026)
- [x] Working installation instructions in README

## What is Admirarr?

[Admirarr](https://github.com/maxtechera/admirarr) is a zero-dependency CLI written in Go that lets you deploy, configure, operate, and diagnose your entire self-hosted media stack from a single terminal command.

### Key features
- `admirarr setup` — Zero to media stack in 15 minutes (12-phase automated deployment)
- `admirarr doctor` — 15 diagnostic categories, 34 checks
- `admirarr status` — Fleet dashboard with live TUI mode
- Covers Jellyfin, Plex, Radarr, Sonarr, Prowlarr, qBittorrent, and 14+ services
- Ships with `SKILL.md` for AI agent integration (Claude Code, Cursor, Gemini CLI, etc.)

### Install
```bash
curl -fsSL https://get.admirarr.dev | sh
```