### PR TITLE
Add CueAPI to automation

### DIFF
--- a/software/cueapi.yml
+++ b/software/cueapi.yml
@@ -1,0 +1,11 @@
+name: CueAPI
+website_url: https://cueapi.ai
+source_code_url: https://github.com/cueapi/cueapi-core
+description: Execution accountability and scheduling infrastructure for AI agents. Tracks whether agents succeeded or failed, with retries and alerts.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Automation


### PR DESCRIPTION
CueAPI is an open source scheduling and execution accountability API for AI agents.

- Website: https://cueapi.ai
- Source: https://github.com/cueapi/cueapi-core
- License: Apache 2.0
- Stack: Python, Docker
- Category: Automation

It tracks whether agents succeeded or failed, with automatic retries and failure alerts.