### PR TITLE
remove Vince demo_url

### DIFF
--- a/software/vince.yml
+++ b/software/vince.yml
@@ -11,7 +11,6 @@ platforms:
   - deb
 tags:
   - Analytics
-demo_url: https://demo.vinceanalytics.com/v1/share/vinceanalytics.com?auth=Ls9tV4pzqOn7BJ7-&demo=true
 stargazers_count: 1999
 updated_at: '2025-09-01'
 archived: false


### PR DESCRIPTION
- ref: #1
- `https://demo.vinceanalytics.com/v1/share/vinceanalytics.com?auth=Ls9tV4pzqOn7BJ7-&demo=true : HTTPSConnectionPool(host='demo.vinceanalytics.com', port=443): Max retries exceeded with url: /v1/share/vinceanalytics.com?auth=Ls9tV4pzqOn7BJ7-&demo=true (Caused by ConnectTimeoutError(<HTTPSConnection(host='demo.vinceanalytics.com', port=443) at 0x7f5089fa1c70>, 'Connection to demo.vinceanalytics.com timed out. (connect timeout=10)'))`
- Demo is unreachable for at least 1 month
