### PR TITLE
remove Picsur demo

### DIFF
--- a/software/picsur.yml
+++ b/software/picsur.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - File Transfer - Single-click & Drag-n-drop Upload
 source_code_url: https://github.com/CaramelFur/Picsur
-demo_url: https://picsur.org/upload
 stargazers_count: 1220
 updated_at: '2025-10-12'
 archived: false


### PR DESCRIPTION
- `ERROR:url_check.py: [868/1453] https://picsur.org/upload : HTTP 502`
- Demo doesn't work for at least a month
