### PR TITLE
remove PicoShare website and demo

### DIFF
--- a/software/picoshare.yml
+++ b/software/picoshare.yml
@@ -1,5 +1,5 @@
 name: PicoShare
-website_url: https://pico.rocks
+website_url: https://github.com/mtlynch/picoshare
 description: Minimalist, easy-to-host service for sharing images and other files.
 licenses:
   - AGPL-3.0
@@ -9,7 +9,6 @@ platforms:
 tags:
   - File Transfer - Single-click & Drag-n-drop Upload
 source_code_url: https://github.com/mtlynch/picoshare
-demo_url: https://demo.pico.rocks
 stargazers_count: 2856
 updated_at: '2026-03-03'
 archived: false


### PR DESCRIPTION
```
https://pico.rocks/ : HTTPSConnectionPool(host='pico.rocks', port=443): Max retries exceeded with url: / (Caused by ConnectTimeoutError(<HTTPSConnection(host='pico.rocks', port=443) at 0x7f57a4381d60>, 'Connection to pico.rocks timed out. (connect timeout=10)'))
https://demo.pico.rocks/ : HTTPSConnectionPool(host='demo.pico.rocks', port=443): Max retries exceeded with url: / (Caused by ConnectTimeoutError(<HTTPSConnection(host='demo.pico.rocks', port=443) at 0x7f57a4722600>, 'Connection to demo.pico.rocks timed out. (connect timeout=10)'))
```
- Demo and website got also removed from project github