### PR TITLE
fix OpenSMTPD source code url

### DIFF
--- a/software/opensmtpd.yml
+++ b/software/opensmtpd.yml
@@ -8,4 +8,4 @@ platforms:
   - deb
 tags:
   - Communication - Email - Mail Transfer Agents
-source_code_url: https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.sbin/smtpd/
+source_code_url: https://github.com/OpenSMTPD/OpenSMTPD/


### PR DESCRIPTION
- Offical website points to the GitHub Repo
- However the GitHub Repo points to https://cvsweb.openbsd.org/src/usr.sbin/smtpd/; Not sure which one to pick, went for now with what the project website points to