### PR TITLE
fix Kutt URL and demo URL

### DIFF
--- a/software/kutt.yml
+++ b/software/kutt.yml
@@ -1,5 +1,5 @@
 name: Kutt
-website_url: https://kutt.it
+website_url: https://kutt.to
 source_code_url: https://github.com/thedevs-network/kutt
 description: Modern URL shortener with support for custom domains and custom URLs.
 licenses:
@@ -9,7 +9,7 @@ platforms:
   - Docker
 tags:
   - URL Shorteners
-demo_url: https://kutt.it
+demo_url: https://kutt.to
 stargazers_count: 10671
 updated_at: '2026-02-27'
 archived: false


### PR DESCRIPTION
> kutt.it domain has been deactivated by the Italian TLD registrar due to the lack of identification documents. I'm in contact with the domain registrar to bring it back as soon as possible.
> Meanwhile, please use kutt.to, all the previous and the future links work with this domain as well.
