### PR TITLE
fixes Reactive Resume demo

### DIFF
--- a/software/reactive-resume.yml
+++ b/software/reactive-resume.yml
@@ -9,7 +9,7 @@ platforms:
 tags:
   - Miscellaneous
 source_code_url: https://github.com/AmruthPillai/Reactive-Resume
-demo_url: https://rxresu.me/app/dashboard/
+demo_url: https://rxresu.me/
 stargazers_count: 36009
 updated_at: '2026-03-24'
 archived: false


### PR DESCRIPTION
- App Dashboard is now behind a login page, therfore this returns an error, points to main page now