### PR TITLE
update Planka to non-free

### DIFF
--- a/software/planka.yml
+++ b/software/planka.yml
@@ -2,7 +2,7 @@ name: Planka
 website_url: https://planka.app/
 description: Realtime kanban board for workgroups (alternative to Trello).
 licenses:
-  - AGPL-3.0
+  - ⊘ Proprietary
 platforms:
   - Nodejs
   - Docker


### PR DESCRIPTION
- Updates License of Planka from `AGPL-3.0` (free) to `⊘ Proprietary` (non-free)
- Planka uses a custom "PLANKA Community License" which limits use for "business purposes or operating PLANKA as a hosted service " see [LICENSE.md](https://github.com/plankanban/planka/blob/master/LICENSE.md)