### PR TITLE
add Airbroke

### DIFF
--- a/software/airbroke.yml
+++ b/software/airbroke.yml
@@ -1,0 +1,12 @@
+name: Airbroke
+website_url: https://airbroke.icorete.ch
+description: Lightweight, Airbrake/Sentry-compatible, PostgreSQL-based error catcher with built-in MCP server. (alternative to Errbit).
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+  - K8S
+tags:
+  - Software Development - Testing
+source_code_url: https://github.com/icoretech/airbroke


### PR DESCRIPTION
- [x] The pull request only adds or updates a single item
- [x] I have searched the existing entries and made sure this item is not a duplicate
- [x] This is not an entry for awesome-sysadmin, staticgen.com, staticsitegenerators.net or dbdb.io
- [x] The entry is formatted according to the instructions in https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/CONTRIBUTING.md
- [x] If the entry includes a demo URL, this demo URL is not only a login page - it showcases the software's actual functionality
- [x] The file is named in `kebab-case`
- [x] Platforms/requirements match a realistic install method (source install or pre-built/package)
- [x] The software is actively maintained
- [x] The software's first release was more than 4 months ago
- [x] The software provides working installation instructions
- [x] I understand that the entry will be published approximately one week after the PR is approved

Airbroke is a lightweight, Airbrake/Sentry-compatible, PostgreSQL-based error catcher with a built-in MCP server. MIT licensed, supports Docker/Kubernetes deployment.