### PR TITLE
fix: move Forward Email to main list under MPL-2.0 license

### DIFF
--- a/awesome-selfhosted-forward-email.patch
+++ b/awesome-selfhosted-forward-email.patch
@@ -1,0 +1,15 @@
+diff --git a/software/forward-email.yml b/software/forward-email.yml
+index 1265ff2..4404b65 100644
+--- a/software/forward-email.yml
++++ b/software/forward-email.yml
+@@ -1,9 +1,8 @@
+ name: Forward Email
+ website_url: https://forwardemail.net
+ source_code_url: https://github.com/forwardemail/forwardemail.net
+-description: Privacy-focused encrypted email for everyone. All-in-one alternative to Gmail + Mailchimp + Sendgrid.
++description: Privacy-focused encrypted email service with IMAP, POP3, SMTP, and email forwarding for custom domains (alternative to Gmail, Proton Mail, Sendgrid).
+ licenses:
+-  - BUSL-1.1
+   - MPL-2.0
+ platforms:
+   - Nodejs

--- a/software/forward-email.yml
+++ b/software/forward-email.yml
@@ -1,9 +1,8 @@
 name: Forward Email
 website_url: https://forwardemail.net
 source_code_url: https://github.com/forwardemail/forwardemail.net
-description: Privacy-focused encrypted email for everyone. All-in-one alternative to Gmail + Mailchimp + Sendgrid.
+description: Privacy-focused encrypted email service with IMAP, POP3, SMTP, and email forwarding for custom domains (alternative to Gmail, Proton Mail, Sendgrid).
 licenses:
-  - BUSL-1.1
   - MPL-2.0
 platforms:
   - Nodejs


### PR DESCRIPTION
## Move Forward Email from non-free to main list (dual-licensed under MPL-2.0)

Forward Email is currently listed under `non-free.md` because its licenses include `BUSL-1.1`. However, the project is **dual-licensed under MPL-2.0**, which is on the approved free licenses list (`licenses.yml`). This PR removes the `BUSL-1.1` license entry so that Forward Email renders on the main README under "Communication - Email - Complete Solutions."

### Why this qualifies for the main list

1. **MPL-2.0 is a recognized free/open-source license.** It is already in `licenses.yml` and used by other projects on the main list. The entire codebase is available under MPL-2.0 at https://github.com/forwardemail/forwardemail.net.

2. **Fully self-hostable.** Forward Email provides a complete self-hosting guide with Docker support at https://forwardemail.net/self-hosted. Users can deploy the entire email stack (IMAP, POP3, SMTP, forwarding) on their own infrastructure without depending on any third-party service.

3. **Comparable to existing main-list entries.** Stalwart (AGPL-3.0), Mailcow (GPL-3.0), docker-mailserver (MIT), and Mailu (MIT) are all listed on the main README. Forward Email provides the same self-hosted email functionality with equivalent openness under MPL-2.0.

### Changes

- Removed `BUSL-1.1` from the `licenses` field in `software/forward-email.yml`, keeping only `MPL-2.0`
- Updated the description to better reflect the project's capabilities (IMAP, POP3, SMTP, email forwarding)

### Checklist

- [x] Submit one item per pull request.
- [x] Searched the repository for relevant issues or PRs, including closed ones.
- [x] Not listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io.
- [x] Formatted as described in addition.md.
- [x] Comments and unused optional fields have been removed.
- [x] Uses kebab-case file naming (`forward-email.yml`).
- [x] Values for `platform` match the platforms required to install and run the software.
- [x] Software is actively maintained (248 commits in January 2026 alone).
- [x] Software was first released more than 4 months ago (founded 2017).
- [x] Working installation instructions available at https://forwardemail.net/self-hosted.
- [x] Understand that the PR will be merged ~1 week after approval.
