### PR TITLE
Add AegisFlow to Generative Artificial Intelligence

### DIFF
--- a/software/aegisflow.yml
+++ b/software/aegisflow.yml
@@ -1,0 +1,12 @@
+name: AegisFlow
+website_url: https://github.com/saivedant169/AegisFlow
+source_code_url: https://github.com/saivedant169/AegisFlow
+description: AI gateway that routes LLM traffic across multiple providers with a policy engine, canary rollouts, and a real-time dashboard.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+  - K8S
+  - Go
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adds AegisFlow to the Generative Artificial Intelligence (GenAI) category.

AI gateway that routes LLM traffic across multiple providers with a policy engine, canary rollouts, and a real-time dashboard.

- Source: https://github.com/saivedant169/AegisFlow
- License: Apache-2.0
- Platforms: Go, Docker, K8S
- 330+ tests, active CI, tagged releases (v0.4.0)