### PR TITLE
Add FireVision IPTV Server

### DIFF
--- a/software/firevision-iptv-server.yml
+++ b/software/firevision-iptv-server.yml
@@ -1,0 +1,12 @@
+name: FireVision IPTV Server
+website_url: https://github.com/akshaynikhare/FireVisionIPTVServer
+description: Self-hosted IPTV channel management platform with admin panel, EPG integration, TV device pairing, and multi-user role-based access.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Media Streaming - Video Streaming
+source_code_url: https://github.com/akshaynikhare/FireVisionIPTVServer
+related_software_url: https://github.com/akshaynikhare/FireVisionIPTV


### PR DESCRIPTION
## Software

**[FireVision IPTV Server](https://github.com/akshaynikhare/FireVisionIPTVServer)**

Self-hosted IPTV channel management platform with admin panel, EPG integration, TV device pairing, and multi-user role-based access.

## Details

- **License:** MIT
- **Platform:** Node.js / Docker
- **Category:** Media Streaming - Video Streaming
- **First release:** November 2025
- **Latest release:** v1.1.4 (April 2026)
- **Companion app:** https://github.com/akshaynikhare/FireVisionIPTV (Amazon FireTV client)

## Checklist

- [x] Actively maintained (recent commits + releases)
- [x] First release more than 4 months ago (November 2025)
- [x] Has working install instructions (Docker Compose)
- [x] MIT licensed
- [x] Fully self-hosted, no third-party cloud dependency
- [x] No application code required before use