### PR TITLE
Uptime monitoring and status pages

### DIFF
--- a/software/pingr.yml
+++ b/software/pingr.yml
@@ -1,0 +1,13 @@
+name: Pingr                                                                                                                                            
+  website_url: https://getpingr.com
+  source_code_url: https://github.com/smaranbhupathi/pingr                                                                                               
+  description: Uptime monitoring and status pages. Monitor URLs, get alerted via Email/Slack/Discord when they go down, and share a public status page
+  with your users.                            
+  licenses:                                                                                                                                              
+    - MIT
+  platforms:                                                                                                                                             
+    - Go                                                    
+    - Nodejs                                                                                                                                             
+  tags:                                                     
+    - Monitoring
+  demo_url: https://getpingr.com

--- a/software/pingr.yml
+++ b/software/pingr.yml
@@ -1,13 +1,20 @@
-name: Pingr                                                                                                                                            
-  website_url: https://getpingr.com
-  source_code_url: https://github.com/smaranbhupathi/pingr                                                                                               
-  description: Uptime monitoring and status pages. Monitor URLs, get alerted via Email/Slack/Discord when they go down, and share a public status page
-  with your users.                            
-  licenses:                                                                                                                                              
-    - MIT
-  platforms:                                                                                                                                             
-    - Go                                                    
-    - Nodejs                                                                                                                                             
-  tags:                                                     
-    - Monitoring
-  demo_url: https://getpingr.com
+name: "Pingr"
+
+website_url: "https://getpingrcom"
+demo_url: "https://getpingr.com"
+source_code_url: "https://github.com/smaranbhupathi/pingr"
+
+description: >
+  Uptime monitoring and public status pages.
+  Monitor URLs, get alerted via Email/Slack/Discord on downtime,
+  and share a status page with your users.
+
+licenses:
+  - MIT
+
+platforms:
+  - Go
+  - Node.js
+
+tags:
+  - Monitoring

--- a/software/pingr.yml
+++ b/software/pingr.yml
@@ -1,20 +1,12 @@
 name: "Pingr"
-
 website_url: "https://getpingrcom"
 demo_url: "https://getpingr.com"
 source_code_url: "https://github.com/smaranbhupathi/pingr"
-
-description: >
-  Uptime monitoring and public status pages.
-  Monitor URLs, get alerted via Email/Slack/Discord on downtime,
-  and share a status page with your users.
-
+description: "Uptime monitoring and public status pages. Monitor URLs, get alerted via Email/Slack/Discord on downtime and share a status page with your users."
 licenses:
   - MIT
-
 platforms:
   - Go
-  - Node.js
-
+  - Nodejs
 tags:
-  - Monitoring
+  - Monitoring & Status Pages


### PR DESCRIPTION
Title: Add Pingr                                                                                                                                       
                                                                                                                                                         
  Description:                                                                                                                                           
  Adds Pingr — open source uptime monitoring and status pages.                                                                                           
                                                                                                                                                         
  - Live demo: https://getpingr.com                                                                                                                      
  - Source: https://github.com/smaranbhupathi/pingr         
  - License: MIT                                   
  - Stack: Go, React, PostgreSQL