### PR TITLE
Add StarRate to Photo Galleries

### DIFF
--- a/software/starrate.yml
+++ b/software/starrate.yml
@@ -4,7 +4,8 @@ description: Lightroom-style photo rating and color labeling for Nextcloud. Shar
 licenses:
   - AGPL-3.0
 platforms:
-  - Nextcloud
+  - PHP
+  - Javascript
 tags:
   - Photo Galleries
 source_code_url: https://github.com/merlin1de/starrate

--- a/software/starrate.yml
+++ b/software/starrate.yml
@@ -1,0 +1,10 @@
+name: StarRate
+website_url: https://apps.nextcloud.com/apps/starrate
+description: Lightroom-style photo rating and color labeling for Nextcloud. Share shootings via guest link — no account required for clients.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nextcloud
+tags:
+  - Photo Galleries
+source_code_url: https://github.com/merlin1de/starrate


### PR DESCRIPTION
StarRate is a Nextcloud app that brings Lightroom-style star ratings and color labels to Nextcloud. Photographers can share shootings via guest link without requiring clients to have a Nextcloud account.