### PR TITLE
rename cal.com to cal.diy

### DIFF
--- a/software/cal.diy.yml
+++ b/software/cal.diy.yml
@@ -1,14 +1,13 @@
-name: Cal.com
-website_url: https://cal.com/
+name: Cal.diy
+website_url: https://cal.diy/
 description: Online appointment scheduling system.
 licenses:
-  - AGPL-3.0
+  - MIT
 platforms:
   - Nodejs
 tags:
   - Booking and Scheduling
-source_code_url: https://github.com/calcom/cal.com
-demo_url: https://app.cal.com/bailey
+source_code_url: https://github.com/calcom/cal.diy
 stargazers_count: 40943
 updated_at: '2026-04-01'
 archived: false


### PR DESCRIPTION
- ref: #1
- `repository not found in search results: https://github.com/calcom/cal.com`
- https://github.com/calcom/cal.diy/pull/28903
- There seems to be exist no demo anymore for cal.diy, so it got removed

I will run update-metadata manually after this.. Since the last few times there was always a repo that errored the run, so we are missing already a metadata update for over a week
