### PR TITLE
fix etherpad source_code url

### DIFF
--- a/software/etherpad.yml
+++ b/software/etherpad.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Office Suites
-source_code_url: https://github.com/ether/etherpad-lite
+source_code_url: https://github.com/ether/etherpad
 demo_url: https://demo.sandstorm.io/appdemo/h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60
 stargazers_count: 18246
 updated_at: '2026-04-16'


### PR DESCRIPTION
- ref: #1
- `repository not found in search results: https://github.com/ether/etherpad-lite`
