### PR TITLE
Add AgentWrit — AI agent credential broker

### DIFF
--- a/software/agentwrit.yml
+++ b/software/agentwrit.yml
@@ -1,0 +1,14 @@
+name: AgentWrit
+website_url: https://github.com/devonartis/agentwrit
+description: Credential broker for AI agents. Each agent gets its own temporary key instead of sharing one API key across all agents. Keys are task-scoped and automatically revoked when the task ends.
+licenses:
+  - ⊘ Proprietary
+platforms:
+  - Go
+  - Docker
+tags:
+  - Federated Identity & Authentication
+source_code_url: https://github.com/devonartis/agentwrit
+stargazers_count: 1
+updated_at: '2026-04-20'
+archived: false


### PR DESCRIPTION
Adding AgentWrit — a free, self-hosted credential broker for AI agents.

**What it does:** Each AI agent gets its own temporary key instead of sharing one API key across all agents. When an agent is compromised, revoke just that agent — everything else keeps working.

**Why this list:** awesome-selfhosted has identity and authentication tools, but nothing specifically for AI agent credentialing. This fills that gap.

**Repo:** https://github.com/devonartis/agentwrit
**License:** Free for internal use (PolyForm Internal Use 1.0.0)
**Platforms:** Go, Docker