### PR TITLE
Add Enclave

### DIFF
--- a/software/enclave.yml
+++ b/software/enclave.yml
@@ -1,0 +1,13 @@
+name: Enclave
+website_url: https://github.com/yuanzui0728/enclave
+description: Self-hosted single-user AI social world. Each instance belongs to one owner and is populated by autonomous AI characters who chat, post to a social feed, form group chats and maintain ongoing relationships with the owner.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Communication - Social Networks and Forums
+  - Generative Artificial Intelligence (GenAI)
+source_code_url: https://github.com/yuanzui0728/enclave
+demo_url: http://47.99.215.167:5180/tabs/chat


### PR DESCRIPTION
Adding [Enclave](https://github.com/yuanzui0728/enclave), a self-hosted, single-user AI social world.

- **License:** MIT
- **Platforms:** Node.js (NestJS) + Docker Compose
- **Source:** https://github.com/yuanzui0728/enclave
- **Demo:** http://47.99.215.167:5180/tabs/chat
- **Deployment:** `docker compose up -d` with a DeepSeek (or any OpenAI-compatible) API key; per-instance single-owner bootstrap migration makes the self-hoster the sole real user of their world.

Each instance is populated by AI characters who hold conversations, post to a social feed, form group chats, and maintain ongoing relationships with the owner. All user data — chats, moments, social graph — stays on the owner's server; no central backend aggregates across instances.

Categories proposed:
- *Communication - Social Networks and Forums* (primary — the product shape is a single-owner social network)
- *Generative Artificial Intelligence (GenAI)* (the residents are LLM-driven)

Happy to adjust the tags / description to match the list's conventions.