### PR TITLE
Add KubeStellar Console

### DIFF
--- a/software/kubestellar-console.yml
+++ b/software/kubestellar-console.yml
@@ -1,0 +1,13 @@
+name: KubeStellar Console
+website_url: https://console.kubestellar.io
+source_code_url: https://github.com/kubestellar/console
+description: AI-powered multi-cluster Kubernetes dashboard with real-time observability, CNCF integrations, and AI-guided operations.
+licenses:
+  - Apache-2.0
+platforms:
+  - Go
+  - Docker
+  - K8S
+tags:
+  - Software Development
+demo_url: https://console.kubestellar.io


### PR DESCRIPTION
Adds [KubeStellar Console](https://console.kubestellar.io) — an open-source, AI-powered multi-cluster Kubernetes dashboard.

## Checklist
- [x] Submit one item per PR
- [x] Searched for existing issues/PRs — none found
- [x] Not listed at awesome-sysadmin, staticgen.com, etc.
- [x] Actively maintained (latest commit this week)
- [x] First released more than 4 months ago
- [x] Working installation instructions in README

## Details
- **Website:** https://console.kubestellar.io
- **Source:** https://github.com/kubestellar/console
- **License:** Apache-2.0
- **Platforms:** Go, Docker, K8S
- **Category:** Software Development
- **Demo:** https://console.kubestellar.io
- **CNCF Sandbox project** (under KubeStellar)

KubeStellar Console provides a unified web dashboard for managing multiple Kubernetes clusters with real-time observability, AI-guided operations, and integrations with 30+ CNCF projects.