### PR TITLE
doc: Bookstack's upstream code repo has migrated to Codeberg

### DIFF
--- a/software/bookstack.yml
+++ b/software/bookstack.yml
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Wikis
-source_code_url: https://github.com/BookStackApp/BookStack
+source_code_url: https://codeberg.org/bookstack/bookstack
 demo_url: https://www.bookstackapp.com/#demo
 stargazers_count: 18713
 updated_at: '2026-04-24'


### PR DESCRIPTION
BookStack's upstream code repo is still present on GitHub but has been officially migrated to Codeberg as of the commit below.

See: https://github.com/BookStackApp/BookStack/commit/c1610c453298770db4c1100863f0aefb55a78eb3
