### PR TITLE
remove BookStack metada

### DIFF
--- a/software/bookstack.yml
+++ b/software/bookstack.yml
@@ -10,22 +10,3 @@ tags:
   - Wikis
 source_code_url: https://codeberg.org/bookstack/bookstack
 demo_url: https://www.bookstackapp.com/#demo
-stargazers_count: 18713
-updated_at: '2026-04-24'
-archived: false
-current_release:
-  tag: v26.03.3
-  published_at: '2026-04-05'
-commit_history:
-  2025-05: 52
-  2025-06: 25
-  2025-07: 46
-  2025-08: 34
-  2025-09: 18
-  2025-10: 33
-  2025-11: 37
-  2025-12: 54
-  2026-01: 16
-  2026-02: 40
-  2026-03: 28
-  2026-04: 37


### PR DESCRIPTION
- ref: #2390
- Removes remaining metadata which cannot be updated and leads to wrong information about the project
