### PR TITLE
update source_code url to codeberg

### DIFF
--- a/software/endurain.yml
+++ b/software/endurain.yml
@@ -1,6 +1,6 @@
 name: Endurain
 website_url: https://docs.endurain.com/
-source_code_url: https://github.com/endurain-project/endurain
+source_code_url: https://codeberg.org/endurain-project/endurain
 description: Fitness tracking service designed to give users full control over their data and hosting environment.
 licenses:
   - AGPL-3.0
@@ -8,22 +8,3 @@ platforms:
   - Docker
 tags:
   - Health and Fitness
-stargazers_count: 1907
-updated_at: '2026-04-29'
-archived: true
-current_release:
-  tag: v0.17.7
-  published_at: '2026-04-17'
-commit_history:
-  2025-05: 349
-  2025-06: 396
-  2025-07: 531
-  2025-08: 99
-  2025-09: 886
-  2025-10: 170
-  2025-11: 78
-  2025-12: 100
-  2026-01: 270
-  2026-02: 20
-  2026-03: 0
-  2026-04: 2


### PR DESCRIPTION
- Source code was moved to codeberg (https://github.com/endurain-project/endurain/commit/ccae41926a4111e73fb8b3d4501600a1f66eb119)
- removes metadata
- ref: #1
- `ERROR:awesome_lint.py: Endurain: the project is archived`
