### PR TITLE
Add BeeCount

### DIFF
--- a/software/beecount.yml
+++ b/software/beecount.yml
@@ -1,0 +1,12 @@
+name: BeeCount
+website_url: https://beecount-website.pages.dev
+source_code_url: https://github.com/TNT-Likely/BeeCount
+description: Cross-platform personal expense tracker with self-hostable cloud sync (BeeCount Cloud), iCloud, Supabase, WebDAV or S3 backends, optional AI bill recognition, and offline-first design. Includes Android, iOS and web clients.
+licenses:
+  - ⊘ Proprietary
+platforms:
+  - Dart
+  - Docker
+tags:
+  - Money, Budgeting & Management
+depends_3rdparty: false


### PR DESCRIPTION
Adds BeeCount – an open-source, privacy-first cross-platform personal expense tracker (Android / iOS / Web) with a self-hostable backend (BeeCount Cloud, Docker-deployable) and additional bring-your-own-cloud sync options (iCloud / Supabase / WebDAV / S3).

- 1.4k★, 200+ forks, active development
- Source code: https://github.com/TNT-Likely/BeeCount
- Demo / website: https://beecount-website.pages.dev
- App Store: https://apps.apple.com/app/id6754611670
- Google Play: https://play.google.com/store/apps/details?id=com.tntlikely.beecount
- License: source-available, custom commercial license (free for personal/non-commercial use; commercial use requires a paid license). Tagged as `⊘ Proprietary` since the license isn't OSI/FSF/DFSG-approved. Happy to follow guidance if a different existing identifier in `licenses-nonfree.yml` would be a better fit, or if a new identifier should be registered.
- **Affiliation disclosure**: I am the author and primary maintainer of BeeCount.

Checklist:
- [x] Submit one item per pull request.
- [x] Searched the repository for relevant issues / PRs.
- [x] Software is not already listed in awesome-sysadmin / staticgen / staticsitegenerators / dbdb.io.
- [x] File is formatted as described in [addition.md](.github/ISSUE_TEMPLATE/addition.md).
- [x] Demo links omitted (no public hosted demo for the self-hosted server at this time; the website link is the official site).
- [x] Comments and unused optional fields removed.
- [x] File uses kebab-case (`beecount.yml`).
- [x] `platforms` reflects what's needed to run the server (`Dart`, `Docker`).
- [x] Project is actively maintained.
- [x] First release was more than 4 months ago.
- [x] Working installation instructions are linked from the project README.
- [x] I understand the PR will be merged ~1 week after approval.