### PR TITLE
add Altair

### DIFF
--- a/software/altair.yml
+++ b/software/altair.yml
@@ -1,0 +1,10 @@
+name: Altair
+website_url: https://github.com/dr-h-cyber/Altair
+description: Professional services automation skeleton with resourcing timeline, capacity/utilization, monthly revenue snapshots, project Kanban, skills matrix, and RBAC.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Software Development - Project Management
+source_code_url: https://github.com/dr-h-cyber/Altair


### PR DESCRIPTION
Adds [Altair](https://github.com/dr-h-cyber/Altair), an MIT-licensed Professional Services Automation (PSA) skeleton.

**What it is:** Resourcing timeline, capacity/utilization dashboards (PTO + holidays factored in), monthly revenue snapshots with hard / soft-at-risk / soft-unconfirmed splits, margin analysis with cost-rate history, project Kanban grouped by PM, skills matrix, mentor tree, RBAC via Casbin + RLS.

**Stack:** React 19 + TypeScript + Vite frontend, Vercel serverless functions, self-hosted Supabase (Postgres + Realtime). One-command local bootstrap (`npm run bootstrap:local`) via `supabase start`. Drops cleanly into a fresh Postgres via `supabase/schema.sql`.

**Self-hostable:** Yes — entirely. The Vercel pieces work locally via `vercel dev` and the Supabase pieces work locally via the Supabase CLI. The repo intentionally has no SaaS component.

**License:** MIT (in `licenses.yml`).

**Category:** Placed under `Software Development - Project Management` — Leantime, OpenProject, Plane, etc. share that section, and this is the closest match. Open to moving it if there's a better fit.

**Maintenance disclosure (per your curation rules):** The README explicitly states the project is not actively maintained as a product — published as a fork-and-customize reference. Recent commit activity is high (just published), but if your reviewers prefer to wait and see active maintenance, that's a reasonable call. Wanted to be upfront rather than have it removed under the unmaintained-project rule later.