### PR TITLE
Add Schautrack

### DIFF
--- a/software/schautrack.yml
+++ b/software/schautrack.yml
@@ -1,0 +1,11 @@
+name: Schautrack
+website_url: https://schautrack.com
+source_code_url: https://github.com/schaurian/schautrack
+description: Nutrition tracker for calories, macros and weight, with daily goals, AI-powered photo estimation (OpenAI, Claude, or Ollama), OpenFoodFacts barcode scanning, passkey/TOTP auth, and account linking for sharing progress.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Docker
+tags:
+  - Health and Fitness


### PR DESCRIPTION
# Add Schautrack — self-hostable nutrition tracker

Adding [Schautrack](https://github.com/schaurian/schautrack), an AGPL-3.0 self-hostable web app for tracking calories, macros, and weight.

## What it does

- Daily calorie + macro logging (protein / carbs / fat / fiber / sugar) with per-user goals and color-coded progress
- AI-powered nutrition estimation from food photos, with OpenAI, Claude, or Ollama as the provider (user-supplied keys)
- Barcode scanning via the OpenFoodFacts API
- Weight tracking (kg / lb)
- Daily notes and recurring todos with streak tracking
- Account linking for sharing progress with friends/family
- Auth: password + TOTP 2FA with backup codes, WebAuthn passkeys, OIDC SSO (Google / Authentik / Keycloak / etc.), step-up auth for sensitive changes, audit log
- Real-time updates via Server-Sent Events
- Single Go binary, ~21 MB Docker image, Helm chart for Kubernetes
- Android app (in closed testing on Google Play)

## Self-hosting

- **Docker:** `docker compose -f compose.yml up -d` with bundled Postgres, ~1 minute to running
- **Kubernetes:** Helm chart at `helm.schautrack.com` (stable + staging channels)
- **Hardware:** runs comfortably in 128 MiB / 50 m CPU
- **Public demo:** [schautrack.com](https://schautrack.com)

## Checklist

- [x] **License:** AGPL-3.0 — [LICENSE](https://github.com/schaurian/schautrack/blob/main/LICENSE)
- [x] **Source code:** https://github.com/schaurian/schautrack
- [x] **Active development:** weekly releases, multi-arch container images via GitHub Actions
- [x] **Documented installation:** [README](https://github.com/schaurian/schautrack#readme) covers Docker, compose, and Helm
- [x] **Self-hostable:** no external services required (AI is opt-in; works fully offline with Ollama)
- [x] **Live instance:** https://schautrack.com (admin can hand out invite codes)
- [x] **Built and run from source** by the author — confirmed working
