### PR TITLE
Add Teable

### DIFF
--- a/software/teable.yml
+++ b/software/teable.yml
@@ -1,0 +1,12 @@
+name: Teable
+website_url: https://teable.io
+description: No-code database with a spreadsheet-like interface, built on Postgres (alternative to Airtable).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Database Management
+source_code_url: https://github.com/teableio/teable
+demo_url: https://app.teable.io/share/shrVgdLiOvNQABtW0yX/view


### PR DESCRIPTION
Adds [Teable](https://teable.io) under **Database Management**.

Teable is a no-code database with a spreadsheet-like UI, built on top of Postgres. It is positioned as a self-hostable alternative to Airtable, and sits naturally alongside the existing entries for Baserow, NocoDB, and Grist.

### Checks against the contribution guidelines

- [x] One item per PR.
- [x] Searched existing issues/PRs (open and closed) for `teable` — no prior submission found.
- [x] Not listed at awesome-sysadmin / staticgen / staticsitegenerators / dbdb.io.
- [x] Actively maintained — last commit on `main` was within the last few days, latest release `release.2026-04-28T09-22-07Z.1576` published 2026-04-30.
- [x] First release is more than 4 months old — repo created 2022-11-01, releases stretch back well over a year.
- [x] Working installation instructions — official Docker Compose setup at https://github.com/teableio/teable/blob/develop/docker/README.md.
- [x] Self-hostable, with no dependency on a single SaaS provider for normal operation.

### Source / license

- Source code: https://github.com/teableio/teable
- License: AGPL-3.0 (the GitHub UI shows "Other" because of bundled notices, but the `LICENSE` file is verbatim AGPLv3 — see https://github.com/teableio/teable/blob/main/LICENSE).
- Stars: ~21k.

### Demo

A public read-only demo base is available at https://app.teable.io/share/shrVgdLiOvNQABtW0yX/view.