### PR TITLE
Add PowerLab

### DIFF
--- a/software/powerlab.yml
+++ b/software/powerlab.yml
@@ -1,0 +1,12 @@
+name: PowerLab
+website_url: https://github.com/neochaotic/powerlab
+source_code_url: https://github.com/neochaotic/powerlab
+description: Self-hosted home server panel with a curated 300+ Docker app catalogue, custom Compose builder, live system telemetry, and first-class support for local AI workloads (Ollama, AnythingLLM, ChatGPT-Next-Web). Sign in with your operating-system credentials, reachable on the LAN at powerlab.local via mDNS.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Nodejs
+  - Docker
+tags:
+  - Self-hosting Solutions


### PR DESCRIPTION
Adds **PowerLab** — a self-hosted home server panel built on Docker Compose, with first-class support for local AI workloads (Ollama, AnythingLLM, ChatGPT-Next-Web, etc.). License is AGPL-3.0.

- **Project:** https://github.com/neochaotic/powerlab
- **License:** AGPL-3.0
- **Platforms:** Go, Node.js, Docker
- **Tag:** Self-hosting Solutions

Highlights: 300+ apps in a curated Compose catalogue, visual Custom App Builder, real-time system telemetry (CPU/RAM/GPU including Apple Silicon detection), file manager with media preview, OS-credential auth (no separate panel account), mDNS announcer at `powerlab.local`.

Tested install on amd64 Linux from the v0.1.0 release tarball.

YAML follows the template in CONTRIBUTING.md.