### PR TITLE
Add TSDProxy

### DIFF
--- a/software/tsdproxy.yml
+++ b/software/tsdproxy.yml
@@ -8,4 +8,4 @@ platforms:
   - Go
   - Docker
 tags:
-  - Web Servers
+  - Remote Access

--- a/software/tsdproxy.yml
+++ b/software/tsdproxy.yml
@@ -1,0 +1,11 @@
+name: TSDProxy
+website_url: https://github.com/almeidapaulopt/tsdproxy
+source_code_url: https://github.com/almeidapaulopt/tsdproxy
+description: Automatic reverse proxy and access to Docker containers through Tailscale.
+licenses:
+  - MIT
+platforms:
+  - Go
+  - Docker
+tags:
+  - Web Servers

--- a/software/tsdproxy.yml
+++ b/software/tsdproxy.yml
@@ -1,7 +1,7 @@
 name: TSDProxy
 website_url: https://github.com/almeidapaulopt/tsdproxy
 source_code_url: https://github.com/almeidapaulopt/tsdproxy
-description: Automatic reverse proxy and access to Docker containers through Tailscale.
+description: Automatic reverse proxy for Docker containers on Tailscale, configured via Docker labels or YAML proxy lists.
 licenses:
   - MIT
 platforms:


### PR DESCRIPTION
## Description

TSDProxy is an automatic reverse proxy that exposes Docker containers through Tailscale networks. It uses Docker labels (`tsdproxy.*`) to create per-container Tailscale machines with automatic HTTPS, providing zero-config secure access to self-hosted services.

- **Source code:** https://github.com/almeidapaulopt/tsdproxy
- **License:** MIT
- **Language:** Go
- **Platforms:** Docker

## Inclusion criteria

- [x] Self-hostable - runs as a Docker container or standalone binary
- [x] MIT licensed (FOSS)
- [x] Actively maintained (regular commits and releases)
- [x] First release (v0.1.0) was October 2024, over 4 months ago
- [x] Working installation instructions in the documentation
- [x] Not listed on awesome-sysadmin, staticgen.com, or other similar lists