### PR TITLE
Add O'Saasy License

### DIFF
--- a/licenses.yml
+++ b/licenses.yml
@@ -131,6 +131,10 @@
   name: Mozilla Public License
   url: https://spdx.org/licenses/MPL-2.0.html
 
+- identifier: O'Saasy
+  name: O'Saasy License
+  url: https://osaasy.dev/
+
 - identifier: OSL-3.0
   name: Open Software License 3.0
   url: https://spdx.org/licenses/OSL-3.0.html

--- a/software/fizzy.yml
+++ b/software/fizzy.yml
@@ -1,0 +1,13 @@
+name: "Fizzy"
+website_url: "https://www.fizzy.do/"
+source_code_url: "https://github.com/basecamp/fizzy"
+description: "Fizzy is a free kanban-based tracking tool for managing bugs, tasks, ideas, and small projects. It focuses on a simple, fast interface and aims to provide a lightweight alternative to more complex project management platforms like Trello, Jira, and Asana."
+licenses:
+  - O'Saasy
+platforms:
+  - Ruby
+  - Docker
+tags:
+  - Task management & To-do lists
+  - Groupware
+  - Resource Planning


### PR DESCRIPTION
Add O'Saasy License (https://osaasy.dev/) needed to add Fizzy (https://www.fizzy.do/) to the software list.