### PR TITLE
Add TSDProxy

### DIFF
--- a/software/tsdproxy.yml
+++ b/software/tsdproxy.yml
@@ -1,0 +1,12 @@
+name: "TSDProxy"
+website_url: "https://almeidapaulopt.github.io/tsdproxy/"
+source_code_url: "https://github.com/almeidapaulopt/tsdproxy"
+description: "Automatic reverse proxy that exposes Docker containers via Tailscale, configured with Docker labels or YAML lists (alternative to Nginx Proxy Manager, Traefik)."
+licenses:
+  - MIT
+platforms:
+  - Go
+  - Docker
+tags:
+  - Web Servers
+depends_3rdparty: true


### PR DESCRIPTION
## Description

TSDProxy is an automatic reverse proxy that exposes Docker containers via Tailscale networks. It uses Docker labels (`tsdproxy.*`) to create per-container Tailscale machines with automatic HTTPS, providing zero-config secure access to self-hosted services.

- **Source code:** https://github.com/almeidapaulopt/tsdproxy
- **License:** MIT
- **Language:** Go
- **Platforms:** Docker
- **Depends on Tailscale:** Yes (coordination server)

## Inclusion criteria

- [x] Self-hostable - runs as a Docker container or standalone binary
- [x] MIT licensed (FOSS)
- [x] Actively maintained (68 commits in the last month, active v2 development)
- [x] First release (v0.1.0) was October 2024, over 4 months ago
- [x] Working installation instructions in the documentation
- [x] Not listed on awesome-sysadmin, staticgen.com, or other similar lists

## Checklist

- [x] Submit one item per pull request
- [x] Searched for existing issues/PRs (previous PR #2426 was closed due to incomplete submission)
- [x] Not already listed on awesome-sysadmin, staticgen.com, etc.
- [x] File formatted per addition.md template
- [x] Comments and unused optional fields removed
- [x] kebab-case file naming (`tsdproxy.yml`)
- [x] Platform values match install requirements
- [x] Actively maintained
- [x] First released more than 4 months ago
- [x] Working installation instructions