### PR TITLE
add RunLoop

### DIFF
--- a/software/runloop.yml
+++ b/software/runloop.yml
@@ -1,0 +1,12 @@
+name: RunLoop
+website_url: https://github.com/EnterpriseX-Platform/RunLoop
+source_code_url: https://github.com/EnterpriseX-Platform/RunLoop
+description: Workflow engine combining a drag-drop DAG editor with multi-runtime code execution (Python/Node.js/Shell/Docker), four pluggable queue backends (Postgres/RabbitMQ/Kafka/Redis Streams), an AES-256-GCM secret vault, and WebSocket-streamed live executions. Three containers, ~140 MiB RAM idle.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Nodejs
+  - Docker
+tags:
+  - Automation


### PR DESCRIPTION
Adding [RunLoop](https://github.com/EnterpriseX-Platform/RunLoop) — a self-hosted workflow engine that combines a drag-drop DAG editor with multi-runtime code execution (Python / Node.js / Shell / Docker), four pluggable queue backends (Postgres / RabbitMQ / Kafka / Redis Streams), an AES-256-GCM secret vault, and WebSocket-streamed live executions.

Listed under `Automation` alongside Apache Airflow, Kestra, Cronicle, Dagu, etc.

**Footprint** (reproducible via [`scripts/bench.sh`](https://github.com/EnterpriseX-Platform/RunLoop/blob/main/scripts/bench.sh) — methodology in [`docs/BENCHMARKS.md`](https://github.com/EnterpriseX-Platform/RunLoop/blob/main/docs/BENCHMARKS.md)):

| | |
|---|---|
| Engine binary (linux/amd64) | 27 MiB |
| Engine + Postgres RAM idle | 47 MiB |
| Full stack RAM idle (+ web) | ~140 MiB |
| Cold start | <1 s |
| Min components | 3 (web + engine + Postgres) |

License: AGPL-3.0. Latest release: [v0.1.2](https://github.com/EnterpriseX-Platform/RunLoop/releases/tag/v0.1.2).

Aware that the curation guide notes new submissions should have established activity — happy to revisit if maintainers prefer a 6-12 month wait, but flagging now in case it's useful for the next directory regeneration.