### PR TITLE
add AgenticMail

### DIFF
--- a/software/agenticmail.yml
+++ b/software/agenticmail.yml
@@ -1,0 +1,12 @@
+name: AgenticMail
+website_url: https://github.com/agenticmail/agenticmail
+source_code_url: https://github.com/agenticmail/agenticmail
+description: Communication platform for AI agents that provisions a real email address, phone number, inbox, and API key per agent, bundling a local Stalwart mail server, Google Voice SMS integration, REST API, MCP server, and CLI.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Communication - Email - Complete Solutions
+depends_3rdparty: true


### PR DESCRIPTION
Adds AgenticMail to the list as a self-hosted email/communication platform purpose-built for AI agents.

## Summary

- Adds `software/agenticmail.yml`
- Category: Communication - Email - Complete Solutions
- License: MIT
- Platforms: Nodejs, Docker
- `depends_3rdparty: true` because the SMS feature uses Google Voice; the mail server itself runs locally (bundled Stalwart)
- Source: https://github.com/agenticmail/agenticmail

## Checklist

- [x] One item per PR
- [x] Searched existing issues and PRs
- [x] Not already listed at awesome-sysadmin or related lists
- [x] Actively maintained
- [x] Working installation instructions in the project README