### PR TITLE
Add Compass Calendar

### DIFF
--- a/software/compass-calendar.yml
+++ b/software/compass-calendar.yml
@@ -1,0 +1,13 @@
+name: Compass Calendar
+website_url: https://www.compasscalendar.com
+source_code_url: https://github.com/SwitchbackTech/compass
+description: Calendar-based task manager (alternative to AppFlowy, Super Productivity).
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Javascript
+  - Nodejs
+tags:
+  - Task Management & To-do Lists
+demo_url: https://app.compasscalendar.com


### PR DESCRIPTION
Adds [Compass Calendar](https://www.compasscalendar.com), a calendar-based task manager.

Thanks for the review =]

A couple notes:
- **demo**: I listed the prod app as the 'demo', because anyone can start using the app immediately without any account signup (data is stored in the browser until they sign up)
- **install guides**: The README summarizes a few ways to get started and also points to full guides in the `docs/` dir in the repo. Setup is also covered on the doc site: https://docs.compasscalendar.com/