### PR TITLE
Add HQ — self-hosted business operations platform with MCP server

### DIFF
--- a/software/hq.yml
+++ b/software/hq.yml
@@ -1,0 +1,19 @@
+# software name
+name: "HQ"
+# URL of the software project's homepage
+website_url: "https://github.com/aiwah-labs/hq"
+# URL where the full source code of the program can be downloaded
+source_code_url: "https://github.com/aiwah-labs/hq"
+# description of what the software does, shorter than 250 characters, sentence case
+description: "Self-hosted business operations platform where teams and AI agents work together — objects, actions, workflows, permissions, admin UI, and an MCP server out of the box."
+# list of license identifiers
+licenses:
+  - MIT
+# list of languages/platforms
+platforms:
+  - Nodejs
+  - Docker
+# list of tags (categories)
+tags:
+  - Software Development - Low Code
+  - Automation


### PR DESCRIPTION
## What

Adds [HQ](https://github.com/aiwah-labs/hq) to the list.

**HQ** is a self-hosted business operations platform (MIT licensed) where teams and AI agents work together. It ships with:
- Objects, actions, workflows, and permissions — define once, available everywhere
- An admin UI (Workshop) for your team
- A built-in MCP server so any MCP client gets typed access to your data and actions
- Clone, hand to a coding agent, and shape it to your business

Assigned to Low Code (primary) and Automation tags.

Repo: https://github.com/aiwah-labs/hq