### PR TITLE
Add TradeTally

### DIFF
--- a/software/tradetally.yml
+++ b/software/tradetally.yml
@@ -1,0 +1,23 @@
+name: TradeTally.io
+description: '[TradeTally.io](https://tradetally.io) is a tool designed for day traders and investors to track their trades, analyze performance, and visualize critical metrics over time. Whether self-hosted or used via the official platform, TradeTally provides an alternative to paid services like TraderVue, helping traders make informed decisions through accessible analytics.'
+
+related_tags:
+  - Trading analytics
+  - Trade journaling
+  - Investment tracking
+  - Performance metrics
+
+external_links:
+  - title: TradeTally GitHub
+    url: https://github.com/GeneBO98/tradetally
+
+licenses:
+  - identifier: Apache-2.0
+    name: Apache License 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0
+
+platforms:
+  - name: JavaScript
+    description: "[JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) is a versatile, high-level programming language that is a core technology of the World Wide Web."
+  - name: Vue.js
+    description: "[Vue.js](https://vuejs.org/) is a progressive JavaScript framework used for building user interfaces and single-page applications."

--- a/software/tradetally.yml
+++ b/software/tradetally.yml
@@ -1,23 +1,13 @@
-name: TradeTally.io
-description: '[TradeTally.io](https://tradetally.io) is a tool designed for day traders and investors to track their trades, analyze performance, and visualize critical metrics over time. Whether self-hosted or used via the official platform, TradeTally provides an alternative to paid services like TraderVue, helping traders make informed decisions through accessible analytics.'
-
-related_tags:
-  - Trading analytics
-  - Trade journaling
-  - Investment tracking
-  - Performance metrics
-
-external_links:
-  - title: TradeTally GitHub
-    url: https://github.com/GeneBO98/tradetally
-
+name: TradeTally
+website_url: https://tradetally.io/
+source_code_url: https://github.com/GeneBO98/tradetally
+description: Trading journal and analytics platform for tracking trades, performance metrics and P&L across multiple brokers, with CSV
+imports, AI insights and interactive charts.
 licenses:
-  - identifier: Apache-2.0
-    name: Apache License 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0
-
+  - Apache-2.0
 platforms:
-  - name: JavaScript
-    description: "[JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) is a versatile, high-level programming language that is a core technology of the World Wide Web."
-  - name: Vue.js
-    description: "[Vue.js](https://vuejs.org/) is a progressive JavaScript framework used for building user interfaces and single-page applications."
+  - Docker
+  - Nodejs
+tags:
+  - Money, Budgeting & Management
+demo_url: https://tradetally.io/

--- a/software/tradetally.yml
+++ b/software/tradetally.yml
@@ -1,8 +1,7 @@
 name: TradeTally
 website_url: https://tradetally.io/
 source_code_url: https://github.com/GeneBO98/tradetally
-description: Trading journal and analytics platform for tracking trades, performance metrics and P&L across multiple brokers, with CSV
-imports, AI insights and interactive charts.
+description: Self-hosted trading journal and analytics for tracking trades, P&L and performance across multiple brokers.
 licenses:
   - Apache-2.0
 platforms:


### PR DESCRIPTION
Adds TradeTally, a self-hosted trading journal and analytics platform.

- Source: https://github.com/GeneBO98/tradetally
- License: Apache-2.0
- First release: v1.2.8 on 2025-09-03 (8+ months old, well past the 4-month minimum)
- Latest release: v2.6.3 on 2026-05-09
- 30+ tagged releases, active development
- Self-hostable via Docker (potentialmidas/tradetally) or native Node.js
- Live demo: https://tradetally.io (demo account: demo@example.com / DemoUser25)

Tag chosen: "Money, Budgeting & Management" — same tag used by Ghostfolio,
which is the closest existing entry.

Checklist:
- [x] One item per PR
- [x] Searched existing issues/PRs
- [x] Not listed in awesome-sysadmin or other awesome lists
- [x] Actively maintained (commits within the last week)
- [x] More than 4 months since first release
- [x] Working installation instructions in README