### PR TITLE
Add Lumin (open-source platform for running LLM agents in production)

### DIFF
--- a/software/lumin.yml
+++ b/software/lumin.yml
@@ -1,0 +1,12 @@
+name: Lumin
+website_url: https://github.com/amitbidlan/zistica-lumin
+source_code_url: https://github.com/amitbidlan/zistica-lumin
+description: Local-first AI agent observability with a tenant-isolation firewall built in. Drop-in integrations for LangChain, CrewAI, LlamaIndex, Mastra, VoltAgent, OpenClaw + OTLP receiver for any OpenTelemetry-instrumented agent. Five-layer structural defense against cross-session leaks in multi-tenant bots (per-user file sandbox, deny-by-default for shells/network egress, conversation-history reset on sender switch, Presidio NER prompt scrub, audit trail). Single Docker container, DuckDB-backed.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+  - Python
+  - Nodejs
+tags:
+  - Generative Artificial Intelligence (GenAI)

--- a/software/lumin.yml
+++ b/software/lumin.yml
@@ -1,7 +1,7 @@
 name: Lumin
 website_url: https://github.com/amitbidlan/zistica-lumin
 source_code_url: https://github.com/amitbidlan/zistica-lumin
-description: Local-first observability + security for LLM agents. OWASP LLM Top 10 guardrails (prompt injection, PII redaction, excessive agency) plus tenant-isolation firewall. Drops in via LangChain, CrewAI, LlamaIndex, Mastra, VoltAgent or OTLP.
+description: Open-source platform for LLM agents in production. Observability, policy engine (shadow/enforce, suggester, replay), OWASP LLM Top 10 guardrails (Presidio/Prompt Guard/Llama Guard), approvals, tenant-isolation firewall. 16 framework integrations.
 licenses:
   - Apache-2.0
 platforms:

--- a/software/lumin.yml
+++ b/software/lumin.yml
@@ -1,7 +1,7 @@
 name: Lumin
 website_url: https://github.com/amitbidlan/zistica-lumin
 source_code_url: https://github.com/amitbidlan/zistica-lumin
-description: Local-first AI agent observability with a tenant-isolation firewall built in. Drop-in integrations for LangChain, CrewAI, LlamaIndex, Mastra, VoltAgent, OpenClaw + OTLP receiver for any OpenTelemetry-instrumented agent. Five-layer structural defense against cross-session leaks in multi-tenant bots (per-user file sandbox, deny-by-default for shells/network egress, conversation-history reset on sender switch, Presidio NER prompt scrub, audit trail). Single Docker container, DuckDB-backed.
+description: Local-first AI agent observability with a tenant-isolation firewall. Drop-in integrations for LangChain, CrewAI, LlamaIndex, Mastra, VoltAgent + OTLP receiver. Structurally blocks cross-session leaks in multi-tenant bots.
 licenses:
   - Apache-2.0
 platforms:

--- a/software/lumin.yml
+++ b/software/lumin.yml
@@ -1,7 +1,7 @@
 name: Lumin
 website_url: https://github.com/amitbidlan/zistica-lumin
 source_code_url: https://github.com/amitbidlan/zistica-lumin
-description: Local-first AI agent observability with a tenant-isolation firewall. Drop-in integrations for LangChain, CrewAI, LlamaIndex, Mastra, VoltAgent + OTLP receiver. Structurally blocks cross-session leaks in multi-tenant bots.
+description: Local-first observability + security for LLM agents. OWASP LLM Top 10 guardrails (prompt injection, PII redaction, excessive agency) plus tenant-isolation firewall. Drops in via LangChain, CrewAI, LlamaIndex, Mastra, VoltAgent or OTLP.
 licenses:
   - Apache-2.0
 platforms:


### PR DESCRIPTION
## What

Adding [Lumin](https://github.com/amitbidlan/zistica-lumin) — an open-source platform for running LLM agents in production. Four pillars in one self-hosted Docker container: **Observe, Govern, Defend, Operate.**

## What it covers

1. **Observe** — full-trace recording: every LLM call, tool invocation, retrieval, embedding, cost, eval. Real-time WebSocket dashboard.
2. **Govern** — policy engine (typed DSL, shadow/enforce modes, versioning, rollback, audit). Auto-suggester mines patterns from traces; replay tests draft policies against historical data; drift detection alerts on distribution shifts.
3. **Defend** — 8 detection methods (Presidio NER, Prompt Guard 2, Llama Guard 4, LLM-judge, embedding similarity, indirect-prompt-injection, locally-trainable classifier, regex). 12 starter policy packs: OWASP LLM Top 10, OWASP Agentic 2025, GDPR, HIPAA, PCI-DSS. Attack generator. Tenant-isolation firewall.
4. **Operate** — webhooks (PagerDuty/Slack/SIEM), backups + retention, panic disable, metrics, health, human approvals queue, decisions audit.

## Section

Generative Artificial Intelligence (GenAI)

## Self-hosting

- **Single Docker container** — \`docker run -p 3000:3000 -p 8000:8000 zistica/lumin:0.7.0\`
- **Or docker-compose** — \`docker compose up -d --wait\` from the repo
- **License:** Apache-2.0
- **Stack:** Python (FastAPI), TypeScript (Next.js dashboard), DuckDB

## Why it fits the list

- Self-hostable (single Docker image, no SaaS dependency)
- Active development (v0.7.0 released this week, regular commits)
- Open-source under a permissive license (Apache-2.0)
- Functional / not abandoned
- Distinct value vs other GenAI entries — combines runtime tracing + runtime OWASP guardrails + full policy engine (versioning, suggester, replay, drift) + approvals queue + tenant isolation in one self-hosted package

## 16 framework integrations

Python SDK, TypeScript SDK, LangChain, LangGraph, LlamaIndex, CrewAI, AutoGen, LiteLLM, OpenAI Agents, Pydantic AI, Anthropic, OpenClaw (OTel + diagnostics plugin), Mastra, VoltAgent, OpenAI-compat HTTP proxy, OTLP receiver. Anything that speaks OpenTelemetry works out of the box.

## Links

- Repo: https://github.com/amitbidlan/zistica-lumin
- Docker Hub: https://hub.docker.com/r/zistica/lumin
- 52-second demo: https://youtu.be/hgTntZniuv4

The \`stargazers_count\`, \`updated_at\`, \`current_release\`, and \`commit_history\` fields will be auto-populated by the data-repo bot.