### PR TITLE
Add os-alt to External Links → alternative frontends/portals

### DIFF
--- a/markdown/footer.md
+++ b/markdown/footer.md
@@ -11,7 +11,7 @@
 
 **[`^        back to top        ^`](#awesome-selfhosted)**
 
-- Alternative frontends/portals to discover/filter awesome-selfhosted apps: [awweso.me](https://awweso.me/), [awesome-web.theravenhub](https://awesome-web.theravenhub.com/browse.html), [awesomehub.web.app](https://awesomehub.js.org/list/selfhosted)
+- Alternative frontends/portals to discover/filter awesome-selfhosted apps: [awweso.me](https://awweso.me/), [awesome-web.theravenhub](https://awesome-web.theravenhub.com/browse.html), [awesomehub.web.app](https://awesomehub.js.org/list/selfhosted), [os-alt](https://code-rho-dun.vercel.app/)
 - [Awesome Sysadmin](https://github.com/awesome-foss/awesome-sysadmin) - Curated list of amazingly awesome open source sysadmin resources.
 - Lists of software aimed at privacy and decentralization in some form: [PRISM Break](https://prism-break.org/en/), [privacytools.io](https://www.privacytools.io/), [Alternative Internet](https://redecentralize.github.io/alternative-internet/), [Libre Projects](https://libreprojects.net/), [Easy Indie App](https://easyindie.app)
 - Other Awesome lists: [Awesome Big Data](https://github.com/0xnr/awesome-bigdata), [Awesome Public Datasets](https://github.com/awesomedata/awesome-public-datasets)


### PR DESCRIPTION
Hi awesome-selfhosted maintainers,

Adding a one-line entry to the `External Links → Alternative frontends/portals` list. The new portal mirrors the same shape as the existing three entries (awweso.me, awesome-web.theravenhub, awesomehub.web.app) — a third-party frontend that helps people discover/filter self-hostable software.

**What it adds beyond raw listing:** every alternative carries a setup-time estimate, a $/month VPS sizing, and a freshness flag (alive/stale/dead) derived from live GitHub commit + archive data. Cross-linked to a `/freshness/` leaderboard and `/graveyard/` of archived projects — useful for the same audience that uses awesome-selfhosted as their starting point.

The portal indexes 100 SaaS targets and 294 self-hostable OSS alternatives, with substantial overlap with this list (Nextcloud, Gitea, Vaultwarden, Plausible, Penpot, Mattermost, etc.).

PR scope is one line in `markdown/footer.md`. No tag, software, license, or platform changes.

Checklist (per `.github/PULL_REQUEST_TEMPLATE.md`):
- [x] Submit one item per pull request.
- [x] Searched the repository for relevant issues and PRs — none for this URL or "alternative frontends" wording.
- [N/A] The remaining checklist items are for new software entries; this PR touches only the footer.