### PR TITLE
tools(url-check): exclude GitLab repos from URL check

### DIFF
--- a/.hecat/url-check.yml
+++ b/.hecat/url-check.yml
@@ -10,6 +10,7 @@ steps:
       errors_are_fatal: True
       exclude_regex:
         - '^https://github.com/[\w\.\-]+/[\w\.\-]+$' # don't check URLs that will be processed by the software_metadata module
+        - '^https://gitlab.com/[\w\.\-]+/[\w\.\-]+$' # don't check URLs that will be processed by the software_metadata module
         - '^https://retrospring.net/$' # DDoS protection page, always returns 403
         - '^https://www.taiga.io/$' # always returns 403 Request forbidden by administrative rules
         - '^https://docs.paperless-ngx.com/$' # DDoS protection page, always returns 403


### PR DESCRIPTION
- Currenctly GitLab Repo URLs are still checked via the url-check job
- This is no longer needed, since software_metadata also now supports and performs gitlab checks