### PR TITLE
add Dakera: MCP-native AI agent memory server

### DIFF
--- a/software/dakera.yml
+++ b/software/dakera.yml
@@ -8,4 +8,4 @@ platforms:
   - Rust
   - Docker
 tags:
-  - Generative AI
+  - Generative Artificial Intelligence (GenAI)

--- a/software/dakera.yml
+++ b/software/dakera.yml
@@ -1,0 +1,11 @@
+name: "Dakera"
+website_url: "https://dakera.ai"
+source_code_url: "https://github.com/dakera-ai/dakera-mcp"
+description: "MCP-native AI agent memory server. Provides agents with persistent, decay-weighted recall across sessions via 83 MCP tools, backed by RocksDB and HNSW vector search."
+licenses:
+  - Apache-2.0
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Generative AI


### PR DESCRIPTION
## Summary

Adds Dakera — a self-hosted, MCP-native AI agent memory server — to the Generative AI category.

**YAML entry:** `software/dakera.yml`

**Details:**
- **Website:** https://dakera.ai
- **Source:** https://github.com/dakera-ai/dakera-mcp
- **License:** Apache-2.0
- **Platforms:** Rust, Docker
- **Description:** MCP-native AI agent memory server. Provides agents with persistent, decay-weighted recall across sessions via 83 MCP tools, backed by RocksDB and HNSW vector search.

**Why it belongs:**
- Self-hosted: runs entirely on your own server (Docker image available)
- Active development: v0.11.53, releases weekly
- MCP (Model Context Protocol) compatible — the emerging standard for AI agent tool integration
- 87.8% on the LoCoMo long-term conversational memory benchmark

**Checklist:**
- [x] Source code is available and open-source (Apache-2.0)
- [x] Software can be self-hosted
- [x] Description is under 250 characters
- [x] License is in licenses.yml (Apache-2.0)
- [x] Platform listed (Rust, Docker)
- [x] Tag exists (Generative AI)