### PR TITLE
add Dakera: MCP-native AI agent memory server

### DIFF
--- a/software/dakera.yml
+++ b/software/dakera.yml
@@ -8,4 +8,4 @@ platforms:
   - Rust
   - Docker
 tags:
-  - Generative AI
+  - Generative Artificial Intelligence (GenAI)

--- a/software/dakera.yml
+++ b/software/dakera.yml
@@ -1,0 +1,11 @@
+name: "Dakera"
+website_url: "https://dakera.ai"
+source_code_url: "https://github.com/dakera-ai/dakera-mcp"
+description: "MCP-native AI agent memory server. Provides agents with persistent, decay-weighted recall across sessions via 83 MCP tools, backed by RocksDB and HNSW vector search."
+licenses:
+  - Apache-2.0
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Generative AI


### PR DESCRIPTION
## Software name
Dakera

## Checklist
- [x] Software is self-hostable via Docker image
- [x] Source code publicly available (https://github.com/dakera-ai/dakera-mcp)
- [x] License: Apache-2.0
- [x] Description is under 250 characters
- [x] Tags: Generative AI
- [x] Platforms: Rust, Docker

## Description
Dakera is a self-hosted AI agent memory server — MCP-native, backed by RocksDB persistence and HNSW vector search. Provides agents with persistent, decay-weighted memory recall across sessions via 83 MCP tools. Deployable as a single Docker image.