### PR TITLE
Add Ethora

### DIFF
--- a/software/ethora.yml
+++ b/software/ethora.yml
@@ -1,0 +1,12 @@
+name: Ethora
+website_url: https://ethora.com
+source_code_url: https://github.com/dappros/ethora
+description: Chat and messaging platform with a built-in AI agent / chatbot framework. Ships SDKs for React, native iOS/Android, and WordPress. Self-host the server or use the hosted Ethora Cloud.
+licenses:
+  - Apache-2.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Communication - Custom Communication Systems
+related_software_url: https://github.com/dappros/ethora#ecosystem


### PR DESCRIPTION
Adds **Ethora** — an open-source chat & messaging platform with a built-in AI agent / chatbot framework.

- **Website:** https://ethora.com
- **Source:** https://github.com/dappros/ethora (Apache-2.0, ~530★, actively maintained)
- **Self-hostable:** Node.js server, Docker deploy; or use the hosted Ethora Cloud.
- Ships SDKs for React, native iOS/Android, and WordPress.

Added as `software/ethora.yml`, tagged **Communication - Custom Communication Systems**.

Checklist:
- [x] One item per PR
- [x] Searched existing issues/PRs — not already listed
- [x] Not listed on awesome-sysadmin / staticgen / dbdb.io
- [x] Actively maintained (pushed 2026-05)
- [x] First released well over 4 months ago
- [x] Working installation instructions in the repo README
