### PR TITLE
Add Meridian NIP

### DIFF
--- a/software/meridian-nip.yml
+++ b/software/meridian-nip.yml
@@ -1,0 +1,11 @@
+# https://github.com/MeridianNIP/meridian
+name: Meridian NIP
+website_url: https://meridiannip.com
+source_code_url: https://github.com/MeridianNIP/meridian
+description: Self-hosted DNS / DHCP / IPAM portal with built-in network diagnostics (dig + multi-resolver propagation, DNSSEC chain, traceroute, MTR, port scan, BGP looking glass, IP reputation), certificate lifecycle, scheduled monitors, runbooks, threat intel, and device-config backup — all behind one MFA-gated, audit-chained login. Reader + tooling surface over Infoblox / NetBox / phpIPAM / BlueCat / ISC Kea / LDAP / Entra.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+tags:
+  - Network Utilities


### PR DESCRIPTION
Adds [Meridian NIP](https://github.com/MeridianNIP/meridian), an Apache 2.0 self-hosted DNS / DHCP / IPAM + network-operations portal that just had its first public release (v1.0.1) on 2026-05-14.

It is a reader and tooling surface over external DDI sources (Infoblox / NetBox / phpIPAM / BlueCat / ISC Kea / LDAP / Entra) and runs the usual diagnostic toolset (dig + propagation, DNSSEC chain, traceroute / MTR, port scan, packet capture, SNMP walk, ASN / BGP lookups, IP reputation across 8 DNSBLs, SPF/DKIM/DMARC, subnet calculator, etc.) plus monitors, certificate lifecycle, runbooks, and threat intel — behind one MFA-gated, audit-chained login.

- Code: <https://github.com/MeridianNIP/meridian>
- Site + docs: <https://meridiannip.com>
- Apt repo: <https://meridiannip.com/apt> (signed)
- Releases: pre-built ISO + VM appliance images (.vhdx / .ova / .qcow2) on the v1.0.0 release page
- License: Apache 2.0

Tagged as Network Utilities — the DNS tag is ad-blocking-focused per its description, so it would be a mismatch.