### PR TITLE
Add Bindery — automated book manager for Usenet and torrents

### DIFF
--- a/software/bindery.yml
+++ b/software/bindery.yml
@@ -1,0 +1,12 @@
+name: Bindery
+website_url: https://github.com/vavallee/bindery
+description: Automated book manager for Usenet and torrents. Monitors authors, searches Prowlarr-compatible indexers, and downloads and organizes ebooks and audiobooks.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Go
+tags:
+  - Automation
+  - Document Management - E-books
+source_code_url: https://github.com/vavallee/bindery


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/CONTRIBUTING.md)
- [x] The project has been around for at least 4 months (first release 2025-01)
- [x] The project is actively maintained
- [x] The software is licensed under a Free/Open Source license (MIT)
- [x] The description is under 250 characters, in sentence case, and does not include "open-source", "free", or "self-hosted"
- [x] Both `website_url` and `source_code_url` are included

## About Bindery

Bindery is an automated book download manager in the style of the *arr ecosystem — think Radarr/Sonarr but for ebooks and audiobooks. It monitors author catalogs (via Hardcover or AudiobookShelf), queries Newznab/Torznab indexers through Prowlarr, grabs releases through qBittorrent, SABnzbd, NZBGet, or Transmission, and imports them into an organized library.

- MIT licensed, written in Go + React
- Docker image: `ghcr.io/vavallee/bindery`
- Active development: v1.10.0 released 2026-05-13
- GitHub: https://github.com/vavallee/bindery