### PR TITLE
Add PsyQuiz - browser-based psychology assessment library

### DIFF
--- a/software/psyquiz.yml
+++ b/software/psyquiz.yml
@@ -1,0 +1,12 @@
+name: PsyQuiz
+website_url: https://github.com/ZHIJAC/psyquiz
+description: Browser-based psychology assessment library, 8 frameworks. Free, anonymous, and science-based. Includes embeddable widget. Zero server-side dependencies.
+licenses:
+  - MIT
+platforms:
+  - Javascript
+tags:
+  - Learning and Courses
+source_code_url: https://github.com/ZHIJAC/psyquiz
+demo_url: https://zhijac.github.io/psyquiz/
+archived: false


### PR DESCRIPTION
### Add PsyQuiz

[PsyQuiz](https://github.com/ZHIJAC/psyquiz) is a browser-based psychology assessment library. It includes 8 psychological frameworks (Attachment Style, Big Five, CBT, Flow State, Decision Style, Stress Coping, Social Energy, Mental Age) with an embeddable widget.

#### Features:
- Zero server-side dependencies (pure client-side JavaScript)
- MIT licensed
- 8 science-based frameworks with scoring and interpretation
- Embeddable widget (2 lines of HTML)
- Bilingual (EN/ZH)
- CDN distribution

Live demo: https://zhijac.github.io/psyquiz/
Source: https://github.com/ZHIJAC/psyquiz