### PR TITLE
Add Dekart

### DIFF
--- a/software/dekart.yml
+++ b/software/dekart.yml
@@ -1,0 +1,13 @@
+name: Dekart
+website_url: https://dekart.xyz
+source_code_url: https://github.com/dekart-xyz/dekart
+description: Turn SQL queries into shareable interactive maps. Connects BigQuery, Snowflake, and PostGIS. (alternative to CARTO).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+  - Go
+  - Nodejs
+tags:
+  - Maps and Global Positioning System (GPS)
+  - Analytics


### PR DESCRIPTION
Adds [Dekart](https://dekart.xyz) — turn SQL queries into shareable interactive maps. Connects BigQuery, Snowflake, and PostGIS. (alternative to CARTO).

Source: https://github.com/dekart-xyz/dekart
License: AGPL-3.0
Tags: Maps and Global Positioning System (GPS), Analytics

Disclosure: I'm the author/maintainer of Dekart.

(Reopen of #2462; fixed the lint error — description now ends with a period.)