### PR TITLE
Add transfa

### DIFF
--- a/software/transfa.yml
+++ b/software/transfa.yml
@@ -1,0 +1,11 @@
+name: "transfa"
+website_url: "https://transfa.sh"
+source_code_url: "https://github.com/colapsis/transfa"
+description: "Ephemeral file transfer — upload a file and get a shareable link that expires. Includes a CLI, REST API, MCP server for AI agents, and GitHub Actions integration."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - File Transfer - Single-click & Drag-n-drop Upload


### PR DESCRIPTION
Adds [transfa](https://transfa.sh) — ephemeral file transfer with CLI, REST API, MCP server, and GitHub Actions integration.

- **Homepage:** https://transfa.sh
- **Source:** https://github.com/colapsis/transfa
- **License:** MIT
- **Stack:** Node.js, Docker
- **Tag:** File Transfer - Single-click & Drag-n-drop Upload

Relevant features:
- Links expire (configurable TTL up to 7 days on free tier, unlimited self-hosted)
- SHA-256 integrity verification on download
- Self-hostable with `docker compose up`
- CLI (`npm install -g transfa`), REST API, MCP server for AI agents, GitHub Actions integration

Checklist:
- [x] One item per PR
- [x] No duplicate in the list
- [x] Actively maintained (first release May 2025)
- [x] Working installation instructions (https://transfa.sh/docs)
