### PR TITLE
fix: update source code URL for MindsDB

### DIFF
--- a/software/mindsdb.yml
+++ b/software/mindsdb.yml
@@ -8,7 +8,7 @@ platforms:
   - Python
 tags:
   - Database Management
-source_code_url: https://github.com/mindsdb/mindsdb
+source_code_url: https://github.com/mindsdb/minds-platform
 stargazers_count: 39168
 updated_at: '2026-04-30'
 archived: false


### PR DESCRIPTION
- ref: #1 
- https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/25945830622/job/76273610185
- `repository not found in search results: https://github.com/mindsdb/mindsdb`