### PR TITLE
Add Pharos to Analytics

### DIFF
--- a/software/pharos.yml
+++ b/software/pharos.yml
@@ -1,0 +1,14 @@
+name: Pharos
+website_url: https://pharos.watch/
+description: Stablecoin analytics dashboard tracking 390+ assets with peg health scores, liquidity metrics, and reserve transparency.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Analytics
+demo_url: https://pharos.watch/
+source_code_url: https://github.com/TokenBrice/pharos-watch
+stargazers_count: 17
+updated_at: '2026-05-16'
+archived: false


### PR DESCRIPTION
## Add Pharos

- **Name**: Pharos
- **Website**: https://pharos.watch/
- **Source Code**: https://github.com/TokenBrice/pharos-watch
- **Demo**: https://pharos.watch/
- **License**: MIT
- **Platform**: Nodejs
- **Tag**: Analytics

Pharos is an open-source stablecoin analytics dashboard tracking 390+ assets with peg health scores, liquidity metrics, and reserve transparency. Built with Next.js (static export) deployed on Cloudflare Pages.

### Checklist
- [x] Submit one item per issue/PR
- [x] Searched for existing issues/PRs
- [x] Software is actively maintained (last commit today, May 2026)
- [x] Software was first released more than 4 months ago
- [x] Software has working installation instructions