### PR TITLE
Add n8n Install

### DIFF
--- a/software/n8n-install.yml
+++ b/software/n8n-install.yml
@@ -1,0 +1,11 @@
+name: "n8n Install"
+website_url: "https://github.com/kossakovsky/n8n-install"
+source_code_url: "https://github.com/kossakovsky/n8n-install"
+description: "AI infrastructure deployment platform. Sets up 30+ AI services (n8n, Ollama, Open WebUI, Supabase, Qdrant, Dify, RAGFlow, etc.) with one command via an interactive wizard. Automatic HTTPS through Caddy."
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+tags:
+  - Self-hosting Solutions
+  - Automation


### PR DESCRIPTION
Adds n8n Install — a one-command deployment platform for self-hostable AI infrastructure, in the same category as CasaOS / Umbrel / Cosmos but focused on the AI/automation stack.

**What it deploys** (30+ services, all selectable in an interactive wizard):
- LLM serving: Ollama, Open WebUI, LiteLLM
- Vector / data: Qdrant, Supabase, NocoDB, Postgres
- AI frameworks: Dify, RAGFlow, LightRAG, Flowise
- Automation: n8n (queue mode + workers), SearXNG
- Ops: Caddy (auto HTTPS), Grafana, Prometheus, cAdvisor
- 15+ more (full list in README)

**Why it's distinct from the existing `n8n` entry:** n8n is one of ~30 optional services here — the project's value is the orchestrated stack, HTTPS automation, wizard-based service selection, and queue-mode scaling setup, not n8n itself.

**Status:**
- License: Apache-2.0
- First tagged release: v1.0.0 on 2026-01-07 (>4 months ago)
- Latest release: v1.5.0 (2026-05-17)
- CHANGELOG: yes (Keep a Changelog format)
- 861 stars / 229 forks, actively maintained

Note: previously submitted as #1919 and closed because no tagged release existed at the time. v1.0.0 was created the same day, and the 4-month maturity window has now passed.

- [x] Submit one item per pull request
- [x] Searched repo for relevant issues/PRs
- [x] Not already listed at awesome-sysadmin or other lists
- [x] File formatted per addition.md
- [x] Comments and unused optional fields removed
- [x] kebab-case filename (n8n-install.yml)
- [x] Platforms match install requirements
- [x] Actively maintained
- [x] First released more than 4 months ago
- [x] Working installation instructions