### PR TITLE
Add Hermes Agent, OpenClaw, Claworc to GenAI

### DIFF
--- a/software/claworc.yml
+++ b/software/claworc.yml
@@ -1,0 +1,12 @@
+name: Claworc
+website_url: https://claworc.com/
+source_code_url: https://github.com/gluk-w/claworc
+description: Orchestrator for running multiple isolated AI agent instances across an organization from a single web dashboard, with instance management, LLM token management, automated backups, and multi-user access control.
+licenses:
+  - MIT
+platforms:
+  - Go
+  - Docker
+  - K8S
+tags:
+  - Generative Artificial Intelligence (GenAI)

--- a/software/hermes-agent.yml
+++ b/software/hermes-agent.yml
@@ -1,0 +1,11 @@
+name: Hermes Agent
+website_url: https://hermes-agent.nousresearch.com/
+source_code_url: https://github.com/NousResearch/hermes-agent
+description: Self-improving AI agent that runs on your server, persists what it learns, and gets more capable the longer it runs.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)

--- a/software/openclaw.yml
+++ b/software/openclaw.yml
@@ -1,0 +1,10 @@
+name: OpenClaw
+website_url: https://openclaw.ai/
+source_code_url: https://github.com/openclaw/openclaw
+description: Personal AI assistant that acts on your behalf (email, calendar, check-ins) through messaging apps like WhatsApp, Telegram, Slack, and Discord.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
## Summary

Adds three self-hosted AI agent projects under the existing **Generative Artificial Intelligence (GenAI)** tag:

- **[Hermes Agent](https://hermes-agent.nousresearch.com/)** ([source](https://github.com/NousResearch/hermes-agent)) — MIT, Python/Docker. Self-improving agent from Nous Research.
- **[OpenClaw](https://openclaw.ai/)** ([source](https://github.com/openclaw/openclaw)) — MIT, Nodejs. Personal AI assistant that operates through WhatsApp/Telegram/Slack/Discord.
- **[Claworc](https://claworc.com/)** ([source](https://github.com/gluk-w/claworc)) — MIT, Go/Docker/K8S. Orchestrator for running multiple isolated AI agent instances from a single dashboard.
