### PR TITLE
add CodeFever Community

### DIFF
--- a/software/codefever.yml
+++ b/software/codefever.yml
@@ -1,0 +1,11 @@
+name: CodeFever Community
+website_url: https://codefever.cn
+source_code_url: https://github.com/PGYER/codefever
+description: Self-hosted Git code hosting service with one-line installation, repository management, branch protection, code review, and team collaboration (alternative to Gitea, Forgejo).
+licenses:
+  - MIT
+platforms:
+  - PHP
+  - Docker
+tags:
+  - Software Development - Project Management


### PR DESCRIPTION
## New software entry

**Name:** CodeFever Community
**Website:** https://codefever.cn
**Source code:** https://github.com/PGYER/codefever
**License:** MIT
**Language:** PHP (with Docker)
**Stars:** ~2.8k

## Description

CodeFever Community is a free and open-source, self-hosted Git code hosting service developed and maintained by PGYER (蒲公英) since well before the 4-month minimum-age requirement (project has been public for years; last upstream push Dec 2024). It supports one-line installation, repository management, branch protection, code review, issues, and team collaboration — a self-hostable alternative to Gitea / Forgejo / GitLab.

## Why it belongs on the list

- MIT-licensed and fully self-hostable (Dockerfile and docker-compose.yml in repo)
- Vendor-official: built by PGYER, a developer-tools company operating since 2014 (12+ years), best known as China's leading mobile beta-distribution platform
- Fits cleanly alongside existing entries (Gitea, Forgejo, Gogs, GitBucket) in `Software Development - Project Management`
- Not a third-party wrapper, not a hosted SaaS, no proprietary dependencies

## Compliance checklist

- [x] Project first released > 4 months ago
- [x] Functioning, self-hostable
- [x] Active maintainer (PGYER organization on GitHub)
- [x] Free Software (MIT)
- [x] Has source code repository
- [x] No required proprietary dependencies

Thanks for considering!