### PR TITLE
add Silex

### DIFF
--- a/software/silex.yml
+++ b/software/silex.yml
@@ -1,0 +1,12 @@
+name: Silex
+website_url: https://www.silex.me
+source_code_url: https://github.com/silexlabs/Silex
+description: Visual website builder for static sites. Standard HTML/CSS output, no lock-in, publish to GitLab, FTP, or Nextcloud (alternative to Webflow).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Software Development - Low Code
+demo_url: https://v3.silex.me


### PR DESCRIPTION
Adding Silex, a visual website builder for static sites (https://www.silex.me).

Silex is an open source web-based editor that publishes static HTML/CSS sites to GitLab, FTP, or Nextcloud. Often positioned as a self-hostable alternative to Webflow. Active development under Silex Labs (https://www.silexlabs.org/), v3.7.3 stable released 2026-05-16.

- Source: https://github.com/silexlabs/Silex
- Demo: https://v3.silex.me
- License: AGPL-3.0
- Section: Software Development - Low Code (alongside Halo, Saltcorn, Appsmith, etc.)