### PR TITLE
Add Markus - AI workforce platform (Generative AI)

### DIFF
--- a/software/markus.yml
+++ b/software/markus.yml
@@ -1,0 +1,11 @@
+name: Markus
+website_url: https://github.com/markus-global/markus
+source_code_url: https://github.com/markus-global/markus
+description: Open-source AI workforce platform with persistent memory, governance, and multi-agent collaboration.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adds Markus to the Generative AI section.

Markus is an open-source AI workforce platform that runs complete teams of AI agents. Self-hostable with a single command. AGPL-3.0 licensed.