### PR TITLE
add Domain Intelligence API

### DIFF
--- a/software/domain-intelligence-api.yml
+++ b/software/domain-intelligence-api.yml
@@ -2,7 +2,7 @@
 name: Domain Intelligence API
 website_url: https://oti-labs.com/domain-intelligence-api
 source_code_url: https://github.com/osiris-technical-institute/domain-intelligence-api
-description: Single REST API that aggregates WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (Certificate Transparency logs + DNS bruteforce), and email security posture (SPF, DMARC, and DKIM auto-probed across 29 common selectors) for any domain. Replaces stitching together python-whois, dnspython, raw socket SSL probes, separate subdomain enumeration tools, and SPF/DMARC parsers.
+description: REST API aggregating WHOIS/RDAP, DNS, SSL certificate inspection, subdomain enumeration (CT logs + DNS bruteforce), and email security (SPF/DMARC/DKIM auto-probed across 29 common selectors) for any domain in a single call.
 licenses:
   - MIT
 platforms:

--- a/software/domain-intelligence-api.yml
+++ b/software/domain-intelligence-api.yml
@@ -1,0 +1,11 @@
+# domain-intelligence-api
+name: Domain Intelligence API
+website_url: https://oti-labs.com/domain-intelligence-api
+source_code_url: https://github.com/osiris-technical-institute/domain-intelligence-api
+description: Single REST API that aggregates WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (Certificate Transparency logs + DNS bruteforce), and email security posture (SPF, DMARC, and DKIM auto-probed across 29 common selectors) for any domain. Replaces stitching together python-whois, dnspython, raw socket SSL probes, separate subdomain enumeration tools, and SPF/DMARC parsers.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - DNS


### PR DESCRIPTION
Adding Domain Intelligence API to the list.

**Self-host:** clone the repo, set 2 optional env vars (free OTX + VirusTotal API keys), run with uvicorn. Single FastAPI app, Redis for caching. Graceful degradation if upstream sources fail (always-on DNS bruteforce as structural floor). License: MIT.

**What it does:** Aggregates WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (CT logs + DNS bruteforce), and email security posture (SPF/DMARC/DKIM auto-probed across 29 common selectors) for any domain in a single REST call.

A hosted version exists at oti-labs.com but the project is fully self-hostable. Source: https://github.com/osiris-technical-institute/domain-intelligence-api