### PR TITLE
doc: issue template: remove reviewers-wanted label on new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/addition.md
+++ b/.github/ISSUE_TEMPLATE/addition.md
@@ -2,7 +2,7 @@
 name: Addition
 about: Add new software to the list.
 title: Add SOFTWARE_NAME
-labels: addition, reviewers wanted
+labels: addition
 assignees: ''
 
 ---


### PR DESCRIPTION
- this label has no practical use on issues
- the only practical use of this label is on pull requests, where the Github "native" reviewed/not reviewed status is clearly visible from the main PR list/page anyway

