### PR TITLE
add 3233.io

### DIFF
--- a/software/3233-io.yml
+++ b/software/3233-io.yml
@@ -1,0 +1,11 @@
+name: 3233.io
+website_url: https://3233.io
+source_code_url: https://github.com/253153/3233.io
+description: Private, end-to-end encrypted chat relay with no accounts or emails, where cryptographic keys live only in the browser.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Communication - Custom Communication Systems


### PR DESCRIPTION
Add 3233.io, a private, end-to-end encrypted chat relay — no accounts, no email, keys live only in this browser.