### PR TITLE
Add BirdNET-Go to Internet of Things (IoT)

### DIFF
--- a/software/birdnet-go.yml
+++ b/software/birdnet-go.yml
@@ -1,0 +1,11 @@
+name: BirdNET-Go
+website_url: https://github.com/tphakala/birdnet-go
+source_code_url: https://github.com/tphakala/birdnet-go
+description: Realtime soundscape analyser for birds, bats, and wildlife. Multi-model AI inference with web dashboard, alert rules engine, MQTT/Home Assistant integration, and SSO.
+licenses:
+  - CC-BY-NC-SA-4.0
+platforms:
+  - Go
+  - Docker
+tags:
+  - Internet of Things (IoT)


### PR DESCRIPTION
BirdNET-Go is a self-hosted soundscape analyser that identifies birds, bats, and other wildlife from audio in real-time. It runs multiple AI models in parallel (BirdNET, Google Perch, BattyBirdNET) against soundcard input or RTSP streams and presents detections in a Svelte 5 web UI with live spectrograms, heatmaps, and species analytics.

It supports MQTT publishing with Home Assistant auto-discovery, configurable alert rules with delivery to Discord/Telegram/ntfy/webhooks, OIDC/SSO, TLS management, and runs on anything from a Raspberry Pi to a full server. Available as Docker images or a single static binary for Linux, Windows, and macOS.

- Actively maintained with regular releases
- Docker and native install options
- First release over 4 months ago
- Working installation instructions and wiki documentation