### PR TITLE
Add Prompter to Generative AI - Ollama comparison and benchmarking tool

### DIFF
--- a/software/prompter.yml
+++ b/software/prompter.yml
@@ -1,0 +1,10 @@
+name: Prompter
+website_url: https://github.com/whonixnetworks/prompter
+source_code_url: https://github.com/whonixnetworks/prompter
+description: Terminal-based multi-model comparison, benchmarking, and evaluation tool for Ollama with debate modes.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
## Description

Adds [Prompter](https://github.com/whonixnetworks/prompter) to the Generative Artificial Intelligence (GenAI) category.

Prompter is a terminal-based multi-model comparison, benchmarking, and evaluation tool for Ollama. It supports:
- Multi-model side-by-side comparisons
- Self-review loops (RALPH mode)
- Multi-persona council debates (COUNCIL mode)
- Adversarial interrogation (BULLY mode)
- Standardised benchmarking
- Web search, file read, shell execution, and other tool integrations
- Zero pip dependencies (stdlib only)

**License:** MIT  
**Platform:** Python  
**First release:** v0.1.0 (2026-05-26)