### PR TITLE
add Torrin

### DIFF
--- a/software/torrin.yml
+++ b/software/torrin.yml
@@ -1,0 +1,10 @@
+name: Torrin
+website_url: https://dineshkn-dev.github.io/torrin/
+description: Cross-platform BitTorrent desktop client (Qt 6 Quick, libtorrent 2.x). No ads or bundled telemetry.
+licenses:
+  - GPL-3.0
+platforms:
+  - C++
+tags:
+  - File Transfer - Peer-to-peer Filesharing
+source_code_url: https://github.com/dineshkn-dev/torrin


### PR DESCRIPTION
## Summary

Adds **Torrin** — an open-source BitTorrent desktop client for macOS, Windows, and Linux.

- **Site:** https://dineshkn-dev.github.io/torrin/
- **Source:** https://github.com/dineshkn-dev/torrin
- **License:** GPL-3.0-or-later
- **Tag:** File Transfer - Peer-to-peer Filesharing (same category as Transmission)

Torrin uses Qt 6 Quick + libtorrent 2.x, ships signed portable builds, and has no ads or bundled telemetry. Install instructions are on the README and Releases page.

Note: the project is younger than four months; happy to wait or revisit if policy requires it.

## Checklist

- [x] One item per PR
- [x] Kebab-case filename `software/torrin.yml`
- [x] Actively maintained (CI on main, recent releases)


Made with [Cursor](https://cursor.com)