### PR TITLE
Add Recall - self-hosted spaced repetition calendar

### DIFF
--- a/software/recall.yml
+++ b/software/recall.yml
@@ -1,0 +1,13 @@
+name: Recall
+website_url: https://github.com/Garuda8887/recall
+description: Spaced repetition calendar that schedules reviews using the SM-2 algorithm. Features forgetting curves, a knowledge graph, dark mode, and drag-and-drop scheduling.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Learning and Courses
+source_code_url: https://github.com/Garuda8887/recall
+stargazers_count: 0
+updated_at: '2026-05-26'
+archived: false


### PR DESCRIPTION
## What is Recall?

[Recall](https://github.com/Garuda8887/recall) is a self-hosted spaced repetition calendar that schedules study reviews using the SM-2 algorithm, visualised as a month-view calendar.

## Why it fits

- Fully self-hosted, zero external services
- MIT licensed
- Node.js + SQLite, zero-config setup
- Active project with 15+ features: forgetting curves, knowledge graph, dark mode, drag-and-drop rescheduling, JWT auth

## Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] Software is self-hostable
- [x] MIT license (OSI-approved), listed in `licenses.yml`
- [x] `Nodejs` platform exists in `platforms/`
- [x] `Learning and Courses` tag exists in `tags/`
- [x] Description is factual, under 250 chars, no marketing language
- [x] Source code is on GitHub with accessible public repo
- [x] `archived: false`