### PR TITLE
add PocketPing

### DIFF
--- a/software/pocketping.yml
+++ b/software/pocketping.yml
@@ -1,0 +1,12 @@
+name: PocketPing
+website_url: https://pocketping.io
+source_code_url: https://github.com/Ruwad-io/pocketping
+description: Chat widget that routes website visitor messages to Telegram, Discord or Slack (alternative to Tawk.to and Intercom).
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Go
+  - Docker
+tags:
+  - Communication - Custom Communication Systems


### PR DESCRIPTION
PocketPing is an open-source chat widget where visitors message you on your site and you reply from **Telegram, Discord, or Slack** on your phone — no separate agent dashboard.

- Source: https://github.com/Ruwad-io/pocketping (MIT)
- Website: https://pocketping.io
- Self-host modes:
  - Free Cloudflare Worker (zero server, zero DB): https://github.com/Ruwad-io/pocketping/tree/main/cloudflare-workers/telegram-relay
  - Go bridge-server (Docker): https://github.com/Ruwad-io/pocketping/tree/main/bridge-server
  - Backend SDK (Node, Python, Go, PHP, Ruby): https://github.com/Ruwad-io/pocketping/tree/main/packages

Checklist from the issue template:
- [x] One item per PR
- [x] Searched for relevant issues/PRs
- [x] Not listed at awesome-sysadmin, staticgen.com, etc.
- [x] Actively maintained — last commit today
- [x] First released >4 months ago (`@pocketping/widget` v2.5.1 was published 4 months ago on npm)
- [x] Working installation instructions in the README