### PR TITLE
Add Prunerr

### DIFF
--- a/software/prunerr.yml
+++ b/software/prunerr.yml
@@ -1,0 +1,11 @@
+name: Prunerr
+website_url: https://github.com/helliott20/prunerr
+source_code_url: https://github.com/helliott20/prunerr
+description: Media library cleanup tool for Plex, Sonarr and Radarr. Reclaims disk space by flagging and removing unwanted content using customisable rules, with a review-and-approve deletion queue, grace periods, and disk-pressure automation.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Nodejs
+tags:
+  - Media Management


### PR DESCRIPTION
Adding **Prunerr** — a media library cleanup tool for Plex, Sonarr and Radarr.

- **Source / homepage:** https://github.com/helliott20/prunerr
- **Licence:** MIT
- **Platforms:** Docker, Nodejs
- **Tag:** Media Management

### Guideline checklist
- [x] First released more than 4 months ago (v1.0.0 on 2026-01-25)
- [x] Tagged releases (currently v1.5.8) and actively maintained
- [x] Open licence (MIT, `LICENSE` in repo)
- [x] Description is sentence case, under 250 characters, no "self-hosted/open-source/free", doesn't start with an article or the project name
- [x] Not a PaaS, does not require writing code, not dependent on a specific cloud provider