### PR TITLE
Add InfraCanvas - live visual infra dashboard

### DIFF
--- a/software/infracanvas.yml
+++ b/software/infracanvas.yml
@@ -1,0 +1,11 @@
+name: InfraCanvas
+website_url: https://github.com/bytestrix/InfraCanvas
+source_code_url: https://github.com/bytestrix/InfraCanvas
+description: Live visual map of containers, pods, volumes, and deployments running on any Linux server. Single binary, one-command install.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Docker
+tags:
+  - Personal Dashboards


### PR DESCRIPTION
## What is InfraCanvas?

InfraCanvas is a single Go binary that discovers and visualizes every container, pod, volume, network, and deployment on a Linux host. It serves a live WebSocket-powered dashboard you open in any browser.

**Install:**
```bash
curl -fsSL https://github.com/bytestrix/InfraCanvas/releases/latest/download/install.sh | bash
```

No Docker required, no extra services, no signup. The installer auto-opens a Cloudflare quick-tunnel and prints a public URL.

## Checklist
- [x] Source code is hosted on a public repository
- [x] AGPL-3.0 license
- [x] Actively maintained (latest release < 30 days ago)
- [x] Self-hostable on a plain Linux server
- [x] No mandatory external services (Cloudflare tunnel is optional, used only for easy access)
