### PR TITLE
Add Huiyu-Pi to Software Development - IDE and Tools

### DIFF
--- a/software/huiyu-pi.yml
+++ b/software/huiyu-pi.yml
@@ -1,6 +1,6 @@
 name: Huiyu-Pi
-website_url: https://github.com/huiyu9144/pi-forge
-source_code_url: https://github.com/huiyu9144/pi-forge
+website_url: https://github.com/huiyu9144/Huiyu-Pi
+source_code_url: https://github.com/huiyu9144/Huiyu-Pi
 description: Local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI.
 licenses:
   - MIT

--- a/software/huiyu-pi.yml
+++ b/software/huiyu-pi.yml
@@ -1,7 +1,7 @@
-name: Huiyu-Pi
+﻿name: Huiyu-Pi
 website_url: https://github.com/huiyu9144/Huiyu-Pi
 source_code_url: https://github.com/huiyu9144/Huiyu-Pi
-description: Local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI.
+description: Open-source local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Free self-hosted alternative to Claude Code/Codex CLI.
 licenses:
   - MIT
 platforms:

--- a/software/pi-forge.yml
+++ b/software/pi-forge.yml
@@ -1,0 +1,11 @@
+name: Pi Forge
+website_url: https://github.com/huiyu9144/pi-forge
+source_code_url: https://github.com/huiyu9144/pi-forge
+description: Local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Software Development - IDE & Tools

--- a/software/pi-forge.yml
+++ b/software/pi-forge.yml
@@ -1,4 +1,4 @@
-name: Pi Forge
+name: Huiyu-Pi
 website_url: https://github.com/huiyu9144/pi-forge
 source_code_url: https://github.com/huiyu9144/pi-forge
 description: Local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI.


### PR DESCRIPTION
Add Huiyu-Pi to awesome-selfhosted. Open-source local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Free self-hosted alternative to Claude Code/Codex CLI.

https://github.com/huiyu9144/Huiyu-Pi