### PR TITLE
Add Reinschrift

### DIFF
--- a/software/reinschrift.yml
+++ b/software/reinschrift.yml
@@ -1,0 +1,11 @@
+name: Reinschrift
+website_url: "https://reinschrift.dumke.me"
+source_code_url: "https://github.com/danst0/ReinschriftTodo"
+description: "Task manager that keeps all todos in a single Markdown file, with WebDAV/Nextcloud sync, recurring tasks, OIDC login and PWA support. Also includes a GNOME desktop app and a CLI (alternative to Todoist, Microsoft To Do)."
+licenses:
+  - GPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Task Management & To-do Lists


### PR DESCRIPTION
Adds [Reinschrift](https://github.com/danst0/ReinschriftTodo) — a task manager that keeps all todos in a single Markdown file, with WebDAV/Nextcloud sync, recurring tasks, OIDC login and PWA support. Self-hostable Flask web app with a pre-built Docker image on [GHCR](https://github.com/danst0/ReinschriftTodo/pkgs/container/reinschrift-web); a native GNOME desktop app and CLI are also available.

- First release: December 2025, actively maintained (see [release history](https://github.com/danst0/ReinschriftTodo/releases))
- License: GPL-3.0-or-later
- Website: https://reinschrift.dumke.me

🤖 Generated with [Claude Code](https://claude.com/claude-code)