### PR TITLE
Fix incorrect related_software_url for Medusa (pymedusa)

### DIFF
--- a/software/medusa.yml
+++ b/software/medusa.yml
@@ -8,7 +8,7 @@ platforms:
 tags:
   - Media Management
 source_code_url: https://github.com/pymedusa/Medusa
-related_software_url: https://github.com/medusajs/nextjs-starter-medusa
+related_software_url: https://github.com/pymedusa/frontend
 stargazers_count: 1960
 updated_at: '2026-05-17'
 archived: false


### PR DESCRIPTION
## Summary

The `related_software_url` in `software/medusa.yml` incorrectly pointed to https://github.com/medusajs/nextjs-starter-medusa, which is an entirely different project:

- **MedusaJS** (`medusajs`) = Open-source e-commerce platform (Node.js/TypeScript)
- **pymedusa/Medusa** = Automatic Video Library Manager for TV Shows (Python)

These are two completely unrelated projects that happen to share the name "Medusa".

## Fix

Updated `related_software_url` to point to https://github.com/pymedusa/frontend, which is the official Vue frontend companion project for pymedusa/Medusa.

## Verification
- pymedusa org repos: https://github.com/orgs/pymedusa/repos
- The frontend repo description: "Vue Frontend for Medusa"