### PR TITLE
Add Samovar to Self-hosting Solutions

### DIFF
--- a/software/samovar.yml
+++ b/software/samovar.yml
@@ -1,0 +1,10 @@
+name: Samovar
+website_url: https://github.com/Tubifix77/samovar
+description: Homelab Docker control plane with app-aware backup. Ships quiesce recipes for 20 apps, cron scheduler, S3/B2 remote storage via Restic, and one-click installs from an embedded catalog.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+tags:
+  - Self-hosting Solutions
+source_code_url: https://github.com/Tubifix77/samovar


### PR DESCRIPTION
### Description

Adding [Samovar](https://github.com/Tubifix77/samovar) to **Self-hosting Solutions**.

Single-binary Go homelab Docker manager with app-aware backup orchestration — ships quiesce recipes per app (pg_dump, `occ maintenance:mode`, SQLite WAL checkpoint, etc.) so backups are crash-safe and actually restorable. Also includes an app catalog with one-click installs for 20 common self-hosted apps, cron scheduler, and S3/B2 remote storage via Restic.

- Active development, v1.0.0 released June 2026
- AGPL-3.0 licensed, single Go binary, no runtime dependencies
