### PR TITLE
Add WebRouter – Unified AI API Gateway

### DIFF
--- a/licenses.yml
+++ b/licenses.yml
@@ -27,6 +27,10 @@
   name: Beerware License
   url: https://spdx.org/licenses/Beerware.html
 
+- identifier: BSL-1.1
+  name: Business Source License 1.1
+  url: https://spdx.org/licenses/BSL-1.1.html
+
 - identifier: BSD-2-Clause
   name: BSD 2-clause "Simplified"
   url: https://spdx.org/licenses/BSD-2-Clause.html

--- a/software/webrouter.yml
+++ b/software/webrouter.yml
@@ -1,0 +1,12 @@
+name: "WebRouter"
+website_url: "https://webrouter.tech"
+source_code_url: "https://github.com/candywon/webrouter"
+description: "Unified AI API Gateway: one API key to manage all LLM providers with smart routing, cost tracking, health monitoring, team management, and knowledge base/RAG."
+licenses:
+  - BSL-1.1
+platforms:
+  - Docker
+  - Python
+  - Go
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
### Description

Add [WebRouter](https://webrouter.tech) to the Generative Artificial Intelligence (GenAI) section.

WebRouter is a unified AI API Gateway: one API key to manage all LLM providers (OpenAI, Anthropic, Google, DeepSeek, Qwen, etc) with smart routing, cost tracking, health monitoring, team management, and knowledge base/RAG. Self-hosted with Docker one-click deploy.

Also adds BSL-1.1 (Business Source License 1.1) to licenses.yml.

### Requirements

- [x] The project is self-hosted and can be deployed with Docker.
- [x] The project source code is available on GitHub.
- [x] The project is actively maintained.
- [x] The project was first released more than 4 months ago.
- [x] License BSL-1.1 has been added to licenses.yml.
- [x] Links are in the correct format.