### PR TITLE
Add HookSniff to API Management

### DIFF
--- a/software/hooksniff.yml
+++ b/software/hooksniff.yml
@@ -1,0 +1,12 @@
+name: HookSniff
+website_url: https://hooksniff.vercel.app
+description: Open-source webhook delivery platform with automatic retries, HMAC-SHA256 signatures (Standard Webhooks), dead letter queue, FIFO ordering, smart routing, and real-time analytics.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Rust
+  - Nodejs
+tags:
+  - Software Development - API Management
+source_code_url: https://github.com/servetarslan02/HookSniff


### PR DESCRIPTION
Add HookSniff to the Software Development - API Management category.

**HookSniff** is an open-source webhook delivery platform built in Rust and Next.js.

**Key features:**
- Automatic retries with exponential backoff and jitter
- HMAC-SHA256 signatures (Standard Webhooks compliant)
- Dead letter queue for failed deliveries
- FIFO ordering with sequence numbers
- Smart routing (round-robin, failover, weighted)
- Real-time analytics dashboard
- Self-hosted with Docker support

**Links:**
- GitHub: https://github.com/servetarslan02/HookSniff
- Live: https://hooksniff.vercel.app
- Docs: https://hooksniff.vercel.app/docs