### PR TITLE
Add OpenFamily

### DIFF
--- a/software/openfamily.yml
+++ b/software/openfamily.yml
@@ -1,0 +1,13 @@
+name: OpenFamily
+website_url: https://nexaflowfrance.github.io/OpenFamily/
+source_code_url: https://github.com/NexaFlowFrance/OpenFamily
+description: Family organizer with shared calendar, tasks and chores with kids rewards, shopping lists, meal planning and recipes, budget tracking, a wall-mounted kiosk mode and an optional AI assistant (alternative to Cozi, Skylight Calendar).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Groupware
+  - Task Management & To-do Lists
+demo_url: https://nexaflowfrance.github.io/OpenFamily/demo/


### PR DESCRIPTION
This PR adds OpenFamily, a family organizer: shared calendar, tasks and chores with kids rewards, shopping lists, meal planning and recipes, budget tracking, a wall-mounted kiosk mode and an optional AI assistant (Ollama or another key from Anthropic or OpenAI).

- License: AGPL-3.0
- First release: January 2026 (v1.0.0), latest: v1.2.0
- Live demo: https://nexaflowfrance.github.io/OpenFamily/demo/
- Deployment: Docker Compose, or a one-click Windows installer

Thanks :) 