### PR TITLE
Add DCSServerBot

### DIFF
--- a/software/dcsserverbot.yml
+++ b/software/dcsserverbot.yml
@@ -1,0 +1,10 @@
+name: DCSServerBot
+website_url: https://github.com/Special-K-s-Flightsim-Bots/DCSServerBot
+description: Manage DCS World dedicated servers via Discord — stats, slot blocking, weather injection, SRS/Tacview/Olympus integrations, 30+ plugins.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Games - Administrative Utilities & Control Panels
+source_code_url: https://github.com/Special-K-s-Flightsim-Bots/DCSServerBot


### PR DESCRIPTION
DCSServerBot is a self-hosted Python bot that manages DCS World dedicated servers through Discord. It handles stats, slot blocking, weather injection, and integrates with SRS, Tacview, and Olympus among others (30+ plugins). First release was in May 2021, MIT licensed.