### PR TITLE
fix MindsDB source_code_url

### DIFF
--- a/software/mindsdb.yml
+++ b/software/mindsdb.yml
@@ -8,7 +8,7 @@ platforms:
   - Python
 tags:
   - Database Management
-source_code_url: https://github.com/mindsdb/minds-platform
+source_code_url: https://github.com/mindsdb/minds
 stargazers_count: 39283
 updated_at: '2026-06-08'
 archived: false


### PR DESCRIPTION
- https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/27385083564
- `ERROR:software_metadata.py: repository not found in search results: https://github.com/mindsdb/minds-platform`