### PR TITLE
remove metadata from inventaire

### DIFF
--- a/software/inventaire.yml
+++ b/software/inventaire.yml
@@ -7,6 +7,4 @@ platforms:
   - Nodejs
 tags:
   - Inventory Management
-source_code_url: https://codeberg.org/inventaire/inventaire
-stargazers_count: 458
-updated_at: '2025-05-16'
+source_code_url: https://codeberg.org/inventaire/inventaires


### PR DESCRIPTION
- `ERROR:awesome_lint.py: Inventaire: last updated -393 days, 0:04:43.072686 ago, older than 365 days`
- Latest commit was a few days ago
- Metadata is not updated, as we currently do not support codeberg
