### PR TITLE
remove deb platform from Secluso

### DIFF
--- a/software/secluso.yml
+++ b/software/secluso.yml
@@ -6,7 +6,6 @@ licenses:
   - GPL-3.0
 platforms:
   - Rust
-  - deb
 tags:
   - Video Surveillance
 stargazers_count: 1572


### PR DESCRIPTION
- Does not have a deb package, only a binary release
