### PR TITLE
Add Celerp

### DIFF
--- a/software/celerp.yml
+++ b/software/celerp.yml
@@ -1,0 +1,15 @@
+name: Celerp
+website_url: https://celerp.com
+description: Self-hosted ERP with inventory, invoicing, manufacturing, and accounting. Click-to-edit data entry, 2-minute setup.
+licenses:
+  - BSL-1.1
+platforms:
+  - Python
+  - Docker
+tags:
+  - Resource Planning
+  - Inventory Management
+source_code_url: https://github.com/celerp/celerp
+stargazers_count: 150
+updated_at: '2026-06-14'
+archived: false


### PR DESCRIPTION
Adds [Celerp](https://celerp.com) to the list.

**What it is:** Self-hosted ERP with inventory, invoicing, manufacturing, and accounting.

**Why it belongs here:**
- Click-to-edit data entry (spreadsheet-style bulk editing)
- 2-minute setup (pip install or desktop app with bundled Postgres)
- Free and open source (BSL-1.1 core, MIT modules)
- 18 industry presets, AI operator, event-sourced audit trail
- 3,100+ tests, active development

[Source Code](https://github.com/celerp/celerp) | [Quick Start](https://celerp.com/docs/quickstart.html)