### PR TITLE
Add Nova Core (DVB-to-IP streaming headend)

### DIFF
--- a/software/nova-core.yml
+++ b/software/nova-core.yml
@@ -1,0 +1,10 @@
+name: Nova Core
+website_url: https://github.com/novaheadend/nova-core-releases
+source_code_url: https://github.com/novaheadend/nova-core-releases
+description: DVB-S/S2/T/T2/C to IP streaming headend that turns tuner cards into HTTP-TS, UDP and M3U streams, with a web UI and EPG.
+licenses:
+  - ⊘ Proprietary
+platforms:
+  - Go
+tags:
+  - Media Streaming - Video Streaming


### PR DESCRIPTION
Adds **Nova Core**, a self-hosted DVB-S/S2/T/T2/C to IP streaming headend (HTTP-TS / UDP / M3U output, web UI, EPG). Single static binary, Linux amd64/arm64/armv7.

It is free to use but binary-only, so it is filed as ⊘ Proprietary (non-free). Tagged under Media Streaming - Video Streaming.

- Releases/docs: https://github.com/novaheadend/nova-core-releases