### PR TITLE
add OpenAcme

### DIFF
--- a/software/openacme.yml
+++ b/software/openacme.yml
@@ -1,0 +1,10 @@
+name: OpenAcme
+website_url: https://github.com/sandydasari/openacme
+source_code_url: https://github.com/sandydasari/openacme
+description: Local-first AI workforce platform. Named agents with roles, personas, tools, memory, and per-agent MCP servers self-organize through task delegation. Supports Anthropic, OpenAI, Google, OpenRouter, and Ollama.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adds [OpenAcme](https://github.com/sandydasari/openacme) to the Generative Artificial Intelligence (GenAI) category.

OpenAcme is a local-first AI workforce platform. Named agents with roles, personas, tools, memory, and per-agent MCP servers self-organize through task delegation with dependency tracking. Supports Anthropic, OpenAI, Google, OpenRouter, and Ollama. Sign in with an existing Claude Pro or ChatGPT Plus subscription — no extra API bill. No telemetry; all sessions and tokens stay on your machine.

- [x] One item per PR
- [x] MIT licensed
- [x] Actively maintained
- [x] First released more than 4 months ago
- [x] Has working installation instructions (`npm install -g @openacme/cli`)
- [x] Self-hostable (local daemon, no cloud dependency)
- [x] Not already listed in awesome-sysadmin or related lists