### PR TITLE
Add Team Relay

### DIFF
--- a/software/team-relay.yml
+++ b/software/team-relay.yml
@@ -1,0 +1,13 @@
+name: Team Relay
+website_url: https://github.com/entire-vc/evc-team-relay
+source_code_url: https://github.com/entire-vc/evc-team-relay
+description: Real-time collaborative editing and web publishing for Obsidian vaults, with CRDT sync, shared folders, and a REST API.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+  - Rust
+  - Docker
+tags:
+  - Note-taking & Editors
+depends_3rdparty: false


### PR DESCRIPTION
## Add Team Relay

Self-hosted platform for real-time collaborative editing and web publishing of Obsidian vaults.

**Affiliation disclosure:** I am a maintainer of this project.

**Checklist:**
- Software is actively maintained (most recent commit: 2026-06-16 — multiple fixes merged in June 2026)
- First release (v1.8.7) was published on 2026-02-05 — more than 4 months ago
- License: Apache-2.0 (FOSS, in [approved list](https://github.com/awesome-selfhosted/awesome-selfhosted/blob/master/non-free.md))
- No third-party non-FOSS dependencies required
- Platforms: Python (control plane), Rust (relay server), Docker (deployment)
- Source code is publicly available at https://github.com/entire-vc/evc-team-relay
- Description does not contain redundant terms (self-hosted, free, open-source)
- One software per PR
- Searched for existing entries and PRs — none found