### PR TITLE
add Profile Counter

### DIFF
--- a/software/profile-counter.yml
+++ b/software/profile-counter.yml
@@ -1,0 +1,10 @@
+name: Profile Counter
+website_url: https://counter.othmaro.dev
+source_code_url: https://github.com/othmarodev/profile-counter
+description: Self-hostable page views counter, designed as a drop-in replacement for third-party services like komarev.com/ghpvc and visitor-badge.laobi.icu that periodically go down and reset users' historical counts. Users own the URL (on their own domain) and the data (their own Redis instance). The reference deployment uses any Node.js host (Vercel Edge example provided) plus any HTTP-callable Redis (Upstash example provided). Includes a CLI to seed initial counts when migrating from a previous service.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Analytics


### PR DESCRIPTION
Adding **Profile Counter** under the `Analytics` tag.

## What it is

[Profile Counter](https://github.com/othmarodev/profile-counter) is a self-hostable page views counter for READMEs / personal sites. It's a drop-in replacement for third-party services like [komarev.com/ghpvc](https://komarev.com), [visitor-badge.laobi.icu](https://visitor-badge.laobi.icu) and similar — the kind that periodically go down and reset users' historical view counts.

- **Live deployment**: https://counter.othmaro.dev
- **Source**: https://github.com/othmarodev/profile-counter
- **License**: MIT
- **Language**: JavaScript (Node.js, ~300 lines)

## Why it's a fit for awesome-selfhosted

The whole point of the project is moving people OFF third-party hosted services. Users:
- Own the URL (subdomain on their own domain)
- Own the data (their own Redis instance)
- Can audit and modify the entire codebase (300 lines, MIT)
- Can swap the storage backend in ~5 lines (any HTTP-callable KV)

The README documents Vercel Edge + Upstash Redis as the simplest deployment path (both have generous free tiers), but the code is portable — it's a stateless function that calls `redis.incr(key)`. Nothing locks users to a specific host or KV provider.

## Why a self-hosted analytics tool deserves a spot

The category already lists analytics platforms (Matomo, Plausible, Umami...) — profile-counter is the tiniest possible point on that spectrum: counting views of a single page (or small set of pages, via `?id=`). Not a replacement for Matomo, but for the use case "I want a counter on my GitHub README without depending on a service that might disappear", nothing in the current list fits.

## Project status

The project is recent (initial release this week) but production-deployed, MIT-licensed, and has working CI. I'm open to maintenance feedback before/after merge — happy to address any criteria concerns.

Thanks for maintaining this list. 🙏