### PR TITLE
Add AnythingMCP

### DIFF
--- a/software/anythingmcp.yml
+++ b/software/anythingmcp.yml
@@ -1,0 +1,13 @@
+# yamllint disable rule:line-length
+name: AnythingMCP
+website_url: https://anythingmcp.com
+source_code_url: https://github.com/HelpCode-ai/anythingmcp
+description: Turn any REST/GraphQL API, SQL/NoSQL database or MCP server into no-code connectors for AI assistants (Claude, ChatGPT, Gemini, Copilot, Cursor), exposed over the Model Context Protocol.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+  - Nodejs
+tags:
+  - Automation
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adds AnythingMCP, a self-hostable gateway that turns any REST/GraphQL API, SQL/NoSQL database or existing MCP server into no-code connectors for AI assistants (Claude, ChatGPT, Gemini, Copilot, Cursor) over the Model Context Protocol.

- Source: https://github.com/HelpCode-ai/anythingmcp (AGPL-3.0)
- Website: https://anythingmcp.com
- Deployed via Docker (`./setup.sh`); Node.js/NestJS + Next.js stack.
- Actively maintained, regular releases, >120 stars, created Feb 2026.

Tags: Automation, Generative Artificial Intelligence (GenAI).
