### PR TITLE
Add Platypus

### DIFF
--- a/software/platypus.yml
+++ b/software/platypus.yml
@@ -1,0 +1,11 @@
+name: Platypus
+website_url: https://platypus.chat
+source_code_url: https://github.com/willdady/platypus
+description: Multi-tenant platform for building and managing AI agents with custom prompts, tool use, sub-agents, skills, memory, scheduling and Model Context Protocol (MCP) support. Works with OpenAI, Anthropic, Google, Bedrock and OpenAI-compatible APIs.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adds [Platypus](https://platypus.chat), a self-hosted, multi-tenant platform for building and managing AI agents — custom system prompts, tool use, sub-agents, skills, long-term memory, scheduling, and Model Context Protocol (MCP) support. Works with OpenAI, Anthropic, Google, Bedrock, OpenRouter, and any OpenAI-compatible endpoint (e.g. vLLM/Ollama), so it can run fully self-hosted.

- **License:** MIT
- **Source:** https://github.com/willdady/platypus
- **Deploy:** Docker / Node.js
- **First released:** November 2025 (> 4 months ago)

Guidelines checklist:
- [x] Free and open-source (MIT), self-hostable
- [x] First release more than 4 months ago, with tagged releases
- [x] Single entry added in `software/`, kebab-case filename, alphabetical fields per the template
- [x] Description under 250 characters, sentence case
- [x] Uses an existing tag (Generative Artificial Intelligence)