### PR TITLE
Add Dozzle

### DIFF
--- a/software/dozzle.yml
+++ b/software/dozzle.yml
@@ -1,0 +1,11 @@
+name: Dozzle
+website_url: https://dozzle.dev
+source_code_url: https://github.com/amir20/dozzle
+description: Realtime log viewer for Docker containers, with live filtering, full-text search, and multi-host support.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Go
+tags:
+  - Monitoring & Status Pages


### PR DESCRIPTION
Adds **Dozzle** — a realtime log viewer for Docker containers (live filtering, full-text search, multi-host).

- Website: https://dozzle.dev
- Source: https://github.com/amir20/dozzle
- License: MIT
- Tag: Monitoring & Status Pages

Actively maintained, widely used in self-hosted/homelab setups, and not currently listed. I run it in my own homelab. Entry follows the data schema (the QA bot will enrich stars/release/commit history from the source repo).