### PR TITLE
Add FriRSS

### DIFF
--- a/software/frirss.yml
+++ b/software/frirss.yml
@@ -1,0 +1,11 @@
+name: FriRSS
+website_url: https://github.com/Fripix/frirss
+source_code_url: https://github.com/Fripix/frirss
+description: Self-hostable web frontend for FreshRSS, using its Google Reader API.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Nodejs
+tags:
+  - Feed Readers


### PR DESCRIPTION
Adds **FriRSS**, a self-hostable web frontend for [FreshRSS](https://freshrss.org) via its Google Reader API: clean three-pane reader on desktop, installable PWA on mobile, themes, labels, offline reading, multi-server, OIDC SSO. MIT-licensed, ships as a single Docker image, actively maintained.

Source: https://github.com/Fripix/frirss