### PR TITLE
Add Floe

### DIFF
--- a/software/floe.yml
+++ b/software/floe.yml
@@ -1,0 +1,11 @@
+name: Floe
+website_url: https://floe.one/
+source_code_url: https://github.com/jannskiee/floe
+description: Peer-to-peer file transfer over WebRTC, with a browser app and a command-line client. File data is sent directly between peers and never passes through the server, which only brokers the initial connection.
+platforms:
+  - Nodejs
+  - Go
+licenses:
+  - MIT
+tags:
+  - File Transfer - Peer-to-peer Filesharing


### PR DESCRIPTION
Adds **Floe** under File Transfer - Peer-to-peer Filesharing.

Floe is a peer-to-peer file transfer app built on WebRTC, with a browser app and a Go command-line client. File data is sent directly between peers over an encrypted data channel and never passes through the server; the self-hostable server only brokers the initial WebRTC connection (signaling) and optional TURN relay credentials. Similar in scope to PrivyDrop, which is already listed under the same tag.

- Website: https://floe.one/
- Source: https://github.com/jannskiee/floe