### PR TITLE
add venice-e2ee-proxy

### DIFF
--- a/software/venice-e2ee-proxy.yml
+++ b/software/venice-e2ee-proxy.yml
@@ -1,0 +1,14 @@
+name: venice-e2ee-proxy
+website_url: https://github.com/AxLabs/venice-e2ee-proxy
+source_code_url: https://github.com/AxLabs/venice-e2ee-proxy
+description: Run-it-locally proxy that adds end-to-end encryption to Venice.ai API calls. Plug any OpenAI-compatible agent or software without changes — requests are encrypted with verified TEE attestation (Intel TDX + NVIDIA GPU).
+licenses:
+  - Apache-2.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)
+stargazers_count: 4
+updated_at: '2026-06-22'
+archived: false


### PR DESCRIPTION
Adds [venice-e2ee-proxy](https://github.com/AxLabs/venice-e2ee-proxy) — a run-it-locally, open-source proxy that adds end-to-end encryption to Venice.ai API calls. Any OpenAI-compatible agent or software can use it without code changes: just point the client at the proxy and requests are automatically encrypted with verified TEE attestation (Intel TDX + NVIDIA GPU).

Tagged under **Generative Artificial Intelligence (GenAI)** as infrastructure for self-hosting private AI inference with Venice's TEE-backed models.

- **License**: Apache-2.0
- **Language**: TypeScript / Node.js
- **Docker**: Yes
- **Active**: Last commit June 2026