### PR TITLE
Update website and demo URLs for Faved

### DIFF
--- a/software/faved.yml
+++ b/software/faved.yml
@@ -1,5 +1,5 @@
 name: Faved
-website_url: https://faved.dev/
+website_url: https://faved.to/
 source_code_url: https://github.com/denho/faved
 description: Handcrafted bookmark manager combining powerful tagging, instant search, and a clean, distraction-free interface. Built for large collections and advanced workflows, optimized for efficiency and ease-of-use.
 licenses:
@@ -8,7 +8,7 @@ platforms:
   - Docker
 tags:
   - Bookmarks and Link Sharing
-demo_url: https://demo.faved.dev/
+demo_url: https://demo.faved.to/
 
 stargazers_count: 1138
 updated_at: '2026-06-22'


### PR DESCRIPTION
<!-- If you are adding new software to the list, DO NOT DELETE THE TEXT BELOW . Please make sure relevant boxes are checked [x] -->
<!-- If you are simply updating an existing entry or removing a project, DO delete the text below. -->

The app website has moved to the new domain `faved.dev` -> `faved.to`.

Updating the corresponding URLs in the entry.