### PR TITLE
Add βWave - self-hosted marketing and social syndication engine

### DIFF
--- a/software/betawave.yml
+++ b/software/betawave.yml
@@ -1,0 +1,10 @@
+name: βWave
+website_url: https://betawave.co.uk
+description: Marketing engine with AI content generation, social syndication (X/Telegram/Reddit/Medium), citation tracking, and client management. BYO API keys, white-label.
+licenses:
+  - AGPL-3.0
+platforms:
+  - nodejs
+tags:
+  - Automation
+source_code_url: https://github.com/johnleeblackwell/betawave


### PR DESCRIPTION
Adding βWave, a self-hosted marketing engine. AGPL-3.0, actively maintained, source code at https://github.com/johnleeblackwell/betawave