### PR TITLE
rename docmost to docmost Community Edition

### DIFF
--- a/software/docmost-community-edition.yml
+++ b/software/docmost-community-edition.yml
@@ -1,4 +1,4 @@
-name: docmost
+name: docmost Community Edition
 website_url: https://docmost.com/
 source_code_url: https://github.com/docmost/docmost
 description: Collaborative wiki and documentation software (alternative to Confluence, Notion).


### PR DESCRIPTION
- https://docmost.com/pricing
- was added in https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/987, no idea if the tiered pricing system was already in place at that time
- related https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/1200, /cc @tuaris

> Some projects will have multiple tiers such as "community" and "enterprise" (paid) editions, with advanced features only being present in the paid edition. This is also fine, as long as the Free edition is not artificially crippled (such as limiting the number of users or otherwise violating the DFSG

The Community edition is in fact heavily limited. I don't know where we should put the cursor on what constitutes "excessive" intentional limitations. The core features are there, so I guess the addition of `Community Edition` should be enough to trigger additional scrutiny when evaluating it. https://github.com/docmost/docmost#license

Similar discussion in https://github.com/awesome-foss/awesome-sysadmin-data/issues/29, /cc @Rabenherz112 @technetium1