### PR TITLE
Add Corterm to Remote Access

### DIFF
--- a/software/corterm.yml
+++ b/software/corterm.yml
@@ -1,0 +1,15 @@
+name: Corterm
+website_url: https://corterm.rwecho.top
+description: Self-hosted remote terminal platform with browser-native terminal, session persistence, multi-worker support, and native mobile apps (iOS, Android, HarmonyOS).
+licenses:
+  - MIT
+platforms:
+  - .NET
+  - Docker
+tags:
+  - Remote Access
+source_code_url: https://github.com/monster-echo/CortexTerminal2
+demo_url: https://corterm.rwecho.top
+stargazers_count: 14
+updated_at: '2026-06-26'
+archived: false


### PR DESCRIPTION
Add [Corterm](https://github.com/monster-echo/CortexTerminal2) to the Remote Access category.

Corterm is a self-hosted remote terminal platform:
- Browser-native terminal (xterm.js with WebGL)
- Session persistence — detach and reattach, shell keeps running
- Multi-worker support — connect any number of machines
- Native mobile apps for iOS, Android, and HarmonyOS
- JWT auth, SignalR real-time streaming
- MIT licensed, .NET/Docker deploy

**Homepage:** https://corterm.rwecho.top
**Source:** https://github.com/monster-echo/CortexTerminal2