### PR TITLE
Add Readfine

### DIFF
--- a/software/readfine.yml
+++ b/software/readfine.yml
@@ -1,0 +1,11 @@
+name: Readfine
+website_url: https://readfine.app
+source_code_url: https://github.com/jakublibik/readfine
+description: Web RSS reader with web-scraping feeds, a filter engine, and optional AI features.
+licenses:
+  - AGPL-3.0
+tags:
+  - Feed Readers
+platforms:
+  - Docker
+  - Python


### PR DESCRIPTION
Adds Readfine, a self-hosted web RSS reader.

- Free and open source (AGPL-3.0)
- Self-hostable via Docker Compose
- Source: https://github.com/jakublibik/readfine
- Website/demo: https://readfine.app

It covers RSS/Atom plus web-scraping feeds (CSS selectors) for sites without a feed, a filter engine, readable extraction, and optional bring-your-own-key AI features. Tagged under Feed Readers.