### PR TITLE
Add Ovumcy

### DIFF
--- a/software/ovumcy.yml
+++ b/software/ovumcy.yml
@@ -1,0 +1,11 @@
+name: Ovumcy
+website_url: https://ovumcy.com
+source_code_url: https://github.com/ovumcy/ovumcy-web
+description: Menstrual cycle tracker you run yourself — daily logging, cycle insights, CSV/JSON export, no telemetry.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Docker
+tags:
+  - Health and Fitness


### PR DESCRIPTION
Adds Ovumcy, a self-hostable menstrual cycle tracker.

- **Homepage:** https://ovumcy.com
- **Source:** https://github.com/ovumcy/ovumcy-web
- **License:** AGPL-3.0
- **Category:** Health and Fitness
- **First release:** 2026-02-23 (v0.1.0), more than 4 months ago

Single Go service with a server-rendered web UI, SQLite by default with Postgres as an advanced path, Docker images provided, no telemetry.

- [x] Submit one item per PR.
- [x] Searched the repository for relevant issues or PRs, including closed ones.
- [x] Not already listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, dbdb.io.
- [x] Actively maintained.
- [x] First released more than 4 months ago.
- [x] Has working installation instructions.