### PR TITLE
Add MindGenius AI

### DIFF
--- a/software/mindgenius-ai.yml
+++ b/software/mindgenius-ai.yml
@@ -1,0 +1,15 @@
+name: "MindGenius AI"
+website_url: "https://github.com/xianjianlf2/MindGeniusAI"
+source_code_url: "https://github.com/xianjianlf2/MindGeniusAI"
+description: "AI agent that reads your PDFs and draws editable mind maps live, with a visible tool-calling loop, built-in RAG, and bring-your-own-key support for multiple LLM providers."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Knowledge Management Tools
+  - Generative Artificial Intelligence (GenAI)
+  - Note-taking & Editors
+depends_3rdparty: true
+demo_url: "https://mindgenius.onrender.com"


### PR DESCRIPTION
Adds **MindGenius AI**, an open-source (MIT) self-hostable AI agent that reads your PDFs and draws editable mind maps live.

- Source code: https://github.com/xianjianlf2/MindGeniusAI
- Live demo: https://mindgenius.onrender.com
- Self-hosts as a single Docker image (`ghcr.io/xianjianlf2/mindgeniusai`); also runs via Node.js + pnpm.
- Bring-your-own-key, multi-provider (OpenAI / Claude / DeepSeek / Kimi, or any OpenAI-compatible endpoint, including self-hosted ones); keys never touch the server's disk.

Checklist:
- [x] Submitting one item.
- [x] Searched existing issues/PRs.
- [x] Not listed in awesome-sysadmin or the other referenced lists.
- [x] Actively maintained.
- [x] First released more than 4 months ago.
- [x] Working installation instructions (README + Docker).

`depends_3rdparty` is set to `true` because it calls an external LLM API by default (though it can also point to a self-hosted OpenAI-compatible endpoint).