### PR TITLE
Add IPForge

### DIFF
--- a/software/ipforge.yml
+++ b/software/ipforge.yml
@@ -1,0 +1,12 @@
+name: "IPForge"
+website_url: "https://github.com/betz-anthony/ipforge"
+source_code_url: "https://github.com/betz-anthony/ipforge"
+description: "IP Address Management that pushes DNS + DHCP records to live servers (BIND, ISC Kea, Pi-hole, MS DNS/DHCP, cloud DNS), with subnet heatmap, drift reconciliation, and dual-stack IPv4/IPv6."
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+  - Python
+tags:
+  - DNS
+  - Network Utilities


### PR DESCRIPTION
Adds IPForge — self-hosted IPAM that pushes DNS + DHCP records to live servers (BIND, ISC Kea, Pi-hole, MS DNS/DHCP, cloud DNS) with drift reconciliation and SNMP switchport discovery.

**Key features:**
- Allocate an IP and IPForge writes the DNS + DHCP records to the real servers (BIND AXFR/RFC2136, Kea, Pi-hole, Windows DNS/DHCP, Route53, Azure, GCP, Cloudflare)
- Rollback on any write failure
- Per-subnet heatmap + continuous ping scanning with history
- 7-category drift detection & reconciliation (IPAM ↔ DNS ↔ DHCP ↔ live)
- SNMP switchport discovery (IP ↔ MAC ↔ switchport ↔ VLAN)
- Dual-stack IPv4/IPv6
- GitOps YAML apply + Terraform provider + Python client

**Tech:** FastAPI + PostgreSQL + React, Docker Compose. AGPL-3.0 (server).

Fits under **DNS** and **Network Utilities**.
