### PR TITLE
Add sDeck

### DIFF
--- a/software/sdeck.yml
+++ b/software/sdeck.yml
@@ -1,0 +1,10 @@
+name: sDeck
+website_url: https://itsiurisilva.github.io/sDeck/
+source_code_url: https://github.com/itsiurisilva/sDeck
+description: Touch-optimized control panel for OBS Studio, Spotify, and Twitch chat/moderation, controlled from any browser on your network.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Automation


### PR DESCRIPTION
sDeck is a self-hosted control panel that runs on a streaming PC and is controlled from any browser on the local network. It drives OBS Studio (via OBS WebSocket v5), Spotify playback, Twitch chat/moderation, Streamlabs alerts, and system commands from a touch-optimized grid of configurable buttons — no cloud, no subscription, no dedicated hardware.

- Website: https://itsiurisilva.github.io/sDeck/
- Source: https://github.com/itsiurisilva/sDeck
- License: MIT