### PR TITLE
Add lilbee

### DIFF
--- a/software/lilbee.yml
+++ b/software/lilbee.yml
@@ -1,0 +1,10 @@
+name: lilbee
+website_url: https://lilbee.sh
+source_code_url: https://github.com/tobocop2/lilbee
+description: Search engine and model manager for local LLMs, indexing your files and crawled web pages and answering questions with source citations. Also works with Ollama and LM Studio.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adding **lilbee** to the Generative Artificial Intelligence (GenAI) category.

lilbee is a local-first AI search engine and model manager you run on your own hardware. It runs local models itself (or uses your existing Ollama / LM Studio), indexes your files, code, and crawled web pages, and answers in plain English with source citations. It runs as a service with a REST API and an MCP server, and only touches the cloud if you point it at a cloud model.

The single executable's terminal UI adds a document, then answers with a citation:

![lilbee's terminal UI adding a document, then answering with a citation](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-add.gif)

The same service is also an [Obsidian community plugin](https://community.obsidian.md/plugins/lilbee):

![the lilbee Obsidian community plugin](https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.gif)

New software file: `software/lilbee.yml`
- Name: lilbee — https://lilbee.sh
- Source: https://github.com/tobocop2/lilbee
- License: MIT · Platform: Python · Tag: Generative Artificial Intelligence (GenAI)

I've followed the data format (short description, no redundant terms, SPDX license, an existing tag and platform). Happy to adjust the tag or wording. The metadata fields (stars, release, commit history) are left for the automated bot.
