### PR TITLE
Add AVA

### DIFF
--- a/software/ava.yml
+++ b/software/ava.yml
@@ -1,0 +1,12 @@
+name: AVA
+website_url: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk
+description: AI voice agent for Asterisk/FreePBX. Answers and places calls over AudioSocket/RTP, and lets you mix speech-to-text, LLM and text-to-speech providers or run the whole pipeline locally.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Communication - SIP
+source_code_url: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk
+demo_url: https://demo.agent6789.com


### PR DESCRIPTION
Adds AVA, a self-hosted AI voice agent for Asterisk/FreePBX.

- Answers and places phone calls over AudioSocket/RTP
- Mix speech-to-text, LLM and text-to-speech providers, or run the full pipeline locally
- MIT licensed, active development, first release ~5.5 months ago (v5.1.0, Jan 2026; currently v7.2.0)

Tag: Communication - SIP
Source: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk