### PR TITLE
update startos source_code_url

### DIFF
--- a/software/startos.yml
+++ b/software/startos.yml
@@ -7,7 +7,7 @@ platforms:
   - Rust
 tags:
   - Self-hosting Solutions
-source_code_url: https://github.com/Start9Labs/start-os
+source_code_url: https://github.com/Start9Labs/start-technologies
 stargazers_count: 1931
 updated_at: '2026-06-23'
 archived: false


### PR DESCRIPTION
- `ERROR:software_metadata.py: repository not found in search results: https://github.com/Start9Labs/start-os`
