### PR TITLE
Add ENLIL: self-hosted multi-agent LLM council with post-quantum signed outputs

### DIFF
--- a/software/enlil.yml
+++ b/software/enlil.yml
@@ -1,0 +1,12 @@
+name: ENLIL
+website_url: https://enlil-council.com/
+source_code_url: https://github.com/conchaestradamiguelangel-droid/enlil
+description: Self-hosted multi-agent LLM deliberation council where 9 AI models reason in parallel on every query, producing a synthesized consensus with post-quantum signed outputs (ML-DSA-87, NIST FIPS 204).
+licenses:
+  - GPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)
+demo_url: https://enlil-council.com/dashboard


### PR DESCRIPTION
Adding ENLIL to the Generative Artificial Intelligence (GenAI) category.

ENLIL is a self-hosted multi-agent LLM deliberation framework where 9 AI models reason in parallel on every query and produce a synthesized consensus. Every output is cryptographically signed with ML-DSA-87 (NIST FIPS 204 post-quantum standard).

- Self-hosted (Docker, FastAPI + React)
- BYOK - bring your own OpenRouter API key
- GPL v3, actively maintained
- Live demo: https://enlil-council.com/dashboard
- Source: https://github.com/conchaestradamiguelangel-droid/enlil