### PR TITLE
Add Backspace

### DIFF
--- a/software/backspace.yml
+++ b/software/backspace.yml
@@ -1,0 +1,11 @@
+name: Backspace
+website_url: https://thezwiss.github.io/backspace/
+source_code_url: https://github.com/TheZwiss/backspace
+description: Team chat with channels, roles, voice, video, screen sharing, direct messages, and server-to-server federation between independently owned instances.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Communication - Custom Communication Systems


### PR DESCRIPTION
Adds Backspace, a self-hostable team chat platform with channels and roles, voice and video, screen sharing, direct messages, and server-to-server federation between independently owned instances.

- Source code: https://github.com/TheZwiss/backspace (AGPL-3.0)
- Website: https://thezwiss.github.io/backspace/
- Self-hosted via Docker; actively maintained with tagged releases.
- Category: Communication - Custom Communication Systems

The entry is a single `software/backspace.yml` with only the contributor fields (no auto-generated fields); tag, platforms, and license are validated against the current taxonomy.