### PR TITLE
Add HomeButler

### DIFF
--- a/software/homebutler.yml
+++ b/software/homebutler.yml
@@ -1,0 +1,25 @@
+name: HomeButler
+website_url: https://homebutler.dev
+description: Homelab management tool for monitoring hosts, Docker services, Wake-on-LAN, inventory, and remote operations, with a web dashboard and MCP integrations.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Go
+tags:
+  - Automation
+  - Remote Access
+source_code_url: https://github.com/Higangssh/homebutler
+stargazers_count: 164
+updated_at: '2026-07-07'
+archived: false
+current_release:
+  tag: v0.19.2
+  published_at: '2026-07-07'
+commit_history:
+  2026-02: 118
+  2026-03: 54
+  2026-04: 80
+  2026-05: 5
+  2026-06: 1
+  2026-07: 3

--- a/software/homebutler.yml
+++ b/software/homebutler.yml
@@ -10,16 +10,3 @@ tags:
   - Automation
   - Remote Access
 source_code_url: https://github.com/Higangssh/homebutler
-stargazers_count: 164
-updated_at: '2026-07-07'
-archived: false
-current_release:
-  tag: v0.19.2
-  published_at: '2026-07-07'
-commit_history:
-  2026-02: 118
-  2026-03: 54
-  2026-04: 80
-  2026-05: 5
-  2026-06: 1
-  2026-07: 3


### PR DESCRIPTION
Thanks for maintaining awesome-selfhosted.

This PR adds HomeButler, a self-hosted homelab management tool for monitoring hosts, Docker services, Wake-on-LAN, inventory, and remote operations. It includes a web dashboard and MCP integrations.

Validation:
- `make awesome_lint` passes.
- `make awesome_lint_strict` currently fails on existing unrelated entries with stale update metadata (`Chirpy`, `FeedCord`, `Send`, `sist2`); HomeButler has no strict-lint-specific errors.

Checklist:
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software you are adding is not already listed at any of awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, dbdb.io.
- [x] The file you are adding is formatted as described in addition.md.
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses kebab-case file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.
