### PR TITLE
add Stateful AI Email Agent

### DIFF
--- a/software/stateful-ai-email-agent.yml
+++ b/software/stateful-ai-email-agent.yml
@@ -1,0 +1,13 @@
+name: "Stateful AI Email Agent"
+website_url: "https://github.com/coma/stateful-email-agent-deploy"
+source_code_url: "https://github.com/coma/stateful-email-agent-deploy"
+description: "Enterprise-grade self-hosted, BYOK multi-turn AI email outreach automation platform compiled to native binaries for absolute privacy."
+licenses:
+  - Proprietary
+platforms:
+  - Python
+  - Docker
+tags:
+  - Communication - Email - Mailing Lists and Newsletters
+  - Automation
+depends_3rdparty: true


### PR DESCRIPTION
Hi maintainers,

I'd like to add "Stateful AI Email Agent" to the non-free self-hosted software list.

- Name: Stateful AI Email Agent
- Description: An enterprise-grade, BYOK (Bring Your Own Key) self-hosted AI email outreach agent. It natively handles stateful, multi-turn follow-up conversations using LLMs and is delivered as compiled native binaries (.so) inside Docker for complete intellectual property protection and data privacy.
- License: Proprietary (Commercial BYOK via Gumroad)
- Category: Communication - Email - Mailing Lists and Newsletters / Automation

I have ensured that:
- It meets all contributing guidelines (specifically marked `depends_3rdparty: true` and `licenses: Proprietary`).
- It has working docker-compose instructions in the deployment repository.

Thank you for maintaining this awesome list!