### PR TITLE
Add Wealthfolio

### DIFF
--- a/software/wealthfolio.yml
+++ b/software/wealthfolio.yml
@@ -1,0 +1,11 @@
+name: Wealthfolio
+website_url: https://wealthfolio.app
+source_code_url: https://github.com/wealthfolio/wealthfolio
+description: Private, local-first personal finance and investment tracker covering net worth, holdings, spending, and portfolio simulations, with optional broker auto-sync.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+  - Rust
+tags:
+  - Money, Budgeting & Management


### PR DESCRIPTION
Adds Wealthfolio, a private, local-first personal finance and investment tracker (net worth, holdings, spending, portfolio simulations) with optional broker auto-sync.

- **Website:** https://wealthfolio.app
- **Source:** https://github.com/wealthfolio/wealthfolio (AGPL-3.0)
- **Self-host:** Dockerfile + `compose.yml` in-repo, plus Proxmox and Unraid guides
- **Stars:** ~7.7k

Disclosure: I'm the maintainer of the project.

Checklist:
- [x] Software is open source (AGPL-3.0) and can be self-hosted
- [x] Entry added alphabetically under `software/` as its own YAML file
- [x] Category: Money, Budgeting & Management
- [x] Description is a full sentence, does not start with the project name, ends with a period
- [x] Website and source code URLs are reachable