### PR TITLE
Add Viglet Turing ES

### DIFF
--- a/software/viglet-turing-es.yml
+++ b/software/viglet-turing-es.yml
@@ -1,0 +1,11 @@
+name: Viglet Turing ES
+website_url: https://viglet.org/turing
+source_code_url: https://github.com/openviglet/turing-ce
+description: Enterprise search platform with faceted, semantic and hybrid retrieval, RAG chat and AI agents over a pluggable Solr/Elasticsearch/Lucene backend.
+licenses:
+  - Apache-2.0
+platforms:
+  - Java
+  - Docker
+tags:
+  - Search Engines


### PR DESCRIPTION
Adding **Viglet Turing ES** to the **Search Engines** category.

- Website: https://viglet.org/turing
- Source: https://github.com/openviglet/turing-ce
- License: Apache-2.0 (FOSS)
- Platforms: Java, Docker (self-hostable server)

Open-source enterprise-search platform with faceted, semantic and hybrid retrieval, RAG chat and AI agents over a pluggable Solr/Elasticsearch/Lucene backend. Long-standing, actively maintained project (first release well over 4 months ago). Sits alongside existing entries like Fess and Apache Solr, adding an AI/RAG layer.

I have read the contributing guidelines; metadata fields (stargazers, release, commit history) left for the automated tooling to populate.