### PR TITLE
Add DockPier

### DIFF
--- a/software/dockpier.yml
+++ b/software/dockpier.yml
@@ -1,0 +1,11 @@
+name: DockPier
+website_url: https://github.com/abakermi/dockpier
+source_code_url: https://github.com/abakermi/dockpier
+description: Dashboard that auto-discovers Docker containers and their web UIs from labels, published ports, and reverse proxy configs (alternative to Homepage, Homarr, Dashy).
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Nodejs
+tags:
+  - Personal Dashboards


### PR DESCRIPTION
## Addition

```yaml
name: DockPier
website_url: https://github.com/abakermi/dockpier
source_code_url: https://github.com/abakermi/dockpier
description: Dashboard that auto-discovers Docker containers and their web UIs from labels, published ports, and reverse proxy configs (alternative to Homepage, Homarr, Dashy).
licenses:
  - MIT
platforms:
  - Docker
  - Nodejs
tags:
  - Personal Dashboards
```

## Checklist

- [x] Submit one item per issue.
- [x] Searched for relevant issues or PRs, including closed ones.
- [x] Not listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io.
- [x] Actively maintained.
- [ ] First released more than 4 months ago. *(First release is from July 2026 — I understand if this needs to wait. Happy to have this PR kept open or closed and resubmitted when it qualifies.)*
- [x] Has working installation instructions (docker-compose in README).

## About DockPier

DockPier connects to Docker hosts (socket, TCP+TLS, SSH), auto-discovers running containers using the Docker API, and resolves each container's web UI URL from:
- `dockpier.*` Docker labels
- Traefik / nginx-proxy / Caddy labels
- 50+ well-known image → port mappings
- Published port fallback

Unlike Homepage, Dashy, and Homarr which require manual YAML configuration for each service, DockPier is zero-config by default — new containers appear automatically.

MIT licensed, multi-arch Docker image (amd64 + arm64).