### PR TITLE
Add TriggerEngage

### DIFF
--- a/software/triggerengage.yml
+++ b/software/triggerengage.yml
@@ -1,0 +1,11 @@
+name: TriggerEngage
+website_url: https://triggerengage.com/
+description: Event-based email, SMS and push messaging automation with a visual journey builder, behavioral segments, A/B testing and analytics, as an alternative to Customer.io.
+licenses:
+  - MIT
+platforms:
+  - PHP
+  - Docker
+tags:
+  - Communication - Email - Mailing Lists and Newsletters
+source_code_url: https://github.com/Trigger-engage/server


### PR DESCRIPTION
Adds **TriggerEngage** under *Communication - Email - Mailing Lists and Newsletters* (alongside Mautic/Listmonk).

TriggerEngage is a self-hostable, open-source (MIT) messaging-automation platform for Laravel: event-based email, SMS & push with a visual journey builder, behavioral segments, A/B testing, and a time-series analytics dashboard. It can run standalone or embed into an existing Laravel app, and is a cost-free alternative to Customer.io.

- Website: https://triggerengage.com
- Source: https://github.com/Trigger-engage/server (MIT)
- Docs: https://github.com/Trigger-engage/server/tree/main/docs

Entry follows the schema (manual fields only; the bot fills stargazers/release/history). Happy to adjust tags or wording.