### PR TITLE
Add Chimely

### DIFF
--- a/software/chimely.yml
+++ b/software/chimely.yml
@@ -1,0 +1,12 @@
+name: Chimely
+website_url: https://chimely.dev
+source_code_url: https://github.com/dodopayments/chimely
+description: Self-hostable in-app notification inbox infrastructure with one Rust binary plus Postgres and Redis, a small HTTP API, and a drop-in <Inbox /> React component.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Communication - Custom Communication Systems
+demo_url: https://chimely.dev


### PR DESCRIPTION
Adds Chimely to Communication - Custom Communication Systems. Chimely is an open-source, self-hostable in-app notification inbox infrastructure (Rust + Postgres + Redis) with a drop-in `<Inbox />` React component, a self-hosted alternative to Knock, Courier, MagicBell, and Novu. Repo: https://github.com/dodopayments/chimely  Website: https://chimely.dev  License: AGPL-3.0. Entry follows the list's YAML schema and tagging conventions.
