### PR TITLE
Add rustunnel

### DIFF
--- a/software/rustunnel.yml
+++ b/software/rustunnel.yml
@@ -1,0 +1,11 @@
+name: rustunnel
+website_url: https://rustunnel.com
+source_code_url: https://github.com/joaoh82/rustunnel
+description: Self-hosted secure tunnel server. Expose local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket; multi-region and MCP server for AI agents.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Proxy


### PR DESCRIPTION
### Add software to the list

```yaml
name: rustunnel
website_url: https://rustunnel.com
source_code_url: https://github.com/joaoh82/rustunnel
description: Self-hosted secure tunnel server. Expose local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket; multi-region and MCP server for AI agents.
licenses:
  - AGPL-3.0
platforms:
  - Rust
  - Docker
tags:
  - Proxy
```

Checklist:
- [x] One item per PR
- [x] Searched existing issues/PRs for rustunnel (none found)
- [x] Not already listed at awesome-sysadmin / staticgen / etc.
- [x] Actively maintained (latest release v0.8.1, 2026-06-10; regular commits)
- [x] First release more than 4 months ago (tag `v0.1.0` on 2026-03-12; GitHub Releases from `v0.4.2` on 2026-03-24)
- [x] Working installation instructions in README / docs (`brew install joaoh82/rustunnel/rustunnel`, Docker, self-host docs)

Related: also tracked on the product side as TUNNEL-32 / off-page SEO.