### PR TITLE
Add Tymeslot (Booking and Scheduling)

### DIFF
--- a/software/tymeslot.yml
+++ b/software/tymeslot.yml
@@ -1,0 +1,12 @@
+name: Tymeslot
+website_url: https://tymeslot.app
+source_code_url: https://github.com/Tymeslot/tymeslot
+description: Share booking pages so others can schedule meetings, with a built-in calendar and two-way sync (alternative to Calendly and Cal.com).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Elixir
+  - Docker
+tags:
+  - Booking and Scheduling
+depends_3rdparty: false


### PR DESCRIPTION
Adds Tymeslot to the Booking and Scheduling category.

Tymeslot is a privacy-first meeting-scheduling platform (booking pages plus a built-in
calendar with two-way sync). Built in Elixir/Phoenix, deploys via a single docker run with
Postgres bundled.

- Website: https://tymeslot.app
- Source: https://github.com/Tymeslot/tymeslot
- Licence: AGPL-3.0
- First release: 2026-03-11 (>4 months old at time of submission)
- Actively maintained (releases through July 2026)

Checklist:
- [x] AGPL-3.0 (FSF-free / OSI-approved) — eligible for the main list
- [x] First release > 4 months old
- [x] Actively maintained
- [x] Category tag exists (Booking and Scheduling)
- [x] Platforms valid (Elixir, Docker)