### PR TITLE
add Editkub

### DIFF
--- a/software/editkub.yml
+++ b/software/editkub.yml
@@ -1,0 +1,12 @@
+name: Editkub
+website_url: https://editkub.vercel.app
+description: Privacy-first, open-source video editor that runs in the browser. CapCut alternative with no uploads, no account, no watermark.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Media Management
+source_code_url: https://github.com/9teeedev/editkub
+demo_url: https://editkub.vercel.app


### PR DESCRIPTION
Privacy-first, open-source browser-based video editor. CapCut alternative with AI features, WebGL effects, and local-first export. MIT license, self-hostable via Docker.