### PR TITLE
tags: fix relationships in related_tags

### DIFF
--- a/tags/bookmarks-and-link-sharing.yml
+++ b/tags/bookmarks-and-link-sharing.yml
@@ -1,2 +1,4 @@
 name: Bookmarks and Link Sharing
 description: Software which allows users to add, annotate, edit, and share [bookmarks](https://en.wikipedia.org/wiki/Bookmark_(digital)) of web documents.
+related_tags:
+  - Personal Dashboards

--- a/tags/communication---email---mailing-lists-and-newsletters.yml
+++ b/tags/communication---email---mailing-lists-and-newsletters.yml
@@ -1,2 +1,4 @@
 name: Communication - Email - Mailing Lists and Newsletters
 description: '[Mailing list](https://en.wikipedia.org/wiki/Mailing_list) servers and mass mailing software - one message to many recipients.'
+related_tags:
+  - Customer Relationship Management (CRM)

--- a/tags/conference-management.yml
+++ b/tags/conference-management.yml
@@ -1,2 +1,4 @@
 name: Conference Management
 description: Software for submission of [abstracts](https://en.wikipedia.org/wiki/Abstract_management) and preparation/management of academic conferences.
+related_tags:
+  - Communication - Video Conferencing

--- a/tags/internet-of-things-iot.yml
+++ b/tags/internet-of-things-iot.yml
@@ -1,2 +1,4 @@
 name: Internet of Things (IoT)
 description: '[Internet of Things](https://en.wikipedia.org/wiki/Internet_of_things) describes physical objects with sensors, processing ability, software, and other technologies that connect and exchange data with other devices over the Internet.'
+related_tags:
+  - Automation

--- a/tags/media-management.yml
+++ b/tags/media-management.yml
@@ -6,3 +6,4 @@ related_tags:
   - Media Streaming - Audio Streaming
   - Media Streaming - Multimedia Streaming
   - Media Streaming - Video Streaming
+  - Media Management

--- a/tags/monitoring--status-pages.yml
+++ b/tags/monitoring--status-pages.yml
@@ -5,3 +5,5 @@ redirect:
     url: https://github.com/awesome-foss/awesome-sysadmin#monitoring--status-pages
   - title: awesome-sysadmin/Metrics and Metric Collection
     url: https://github.com/awesome-foss/awesome-sysadmin#metrics--metric-collection
+related_tags:
+  - Personal Dashboards


### PR DESCRIPTION
 - starting with hecat 1.7.0 (https://github.com/nodiscc/hecat/pull/161), if tag A points to tag B in its related_tags, tag B must also point to tag A

```
INFO:awesome_lint.py: Checking consistency of related_tags
ERROR:awesome_lint.py: Automation: related tag Internet of Things (IoT) does not list Automation in its related_tags
ERROR:awesome_lint.py: Communication - Video Conferencing: related tag Conference Management does not list Communication - Video Conferencing in its related_tags
ERROR:awesome_lint.py: Customer Relationship Management (CRM): related tag Communication - Email - Mailing Lists and Newsletters does not list Customer Relationship Management (CRM) in its related_tags
ERROR:awesome_lint.py: Media Management: related tag Media Streaming does not list Media Management in its related_tags
ERROR:awesome_lint.py: Personal Dashboards: related tag Monitoring & Status Pages does not list Personal Dashboards in its related_tags
ERROR:awesome_lint.py: Personal Dashboards: related tag Bookmarks and Link Sharing does not list Personal Dashboards in its related_tags
```