### PR TITLE
Add DayOtter (Booking and Scheduling)

### DIFF
--- a/software/dayotter.yml
+++ b/software/dayotter.yml
@@ -1,0 +1,10 @@
+name: DayOtter
+website_url: https://dayotter.com
+source_code_url: https://github.com/Dayotter/dayotter
+description: AI-native appointment scheduling platform with booking pages, team round-robin, calendar sync, reminders, and payments; the built-in assistant is confirm-first and optional.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+tags:
+  - Booking and Scheduling


### PR DESCRIPTION
Adds **DayOtter** — an AGPL-3.0, self-hostable scheduling platform (a Calendly/Cal.com alternative) with an optional, confirm-first AI assistant.

- Website: https://dayotter.com
- Source: https://github.com/Dayotter/dayotter
- License: AGPL-3.0
- Deploys with Docker Compose (Postgres, Redis, web, worker, Caddy reverse proxy + automatic HTTPS); one-command install script and AWS one-click template included. Docs: `deploy/README.md`, `docs/SELF_HOSTING.md`.
- Self-hosting unlocks every feature (no open-core wall); AI features are optional and off until an API key is set.

Category: Booking and Scheduling.