### PR TITLE
Add Draftmark

### DIFF
--- a/software/draftmark.yml
+++ b/software/draftmark.yml
@@ -1,0 +1,12 @@
+name: "Draftmark"
+website_url: "https://draftmark.app"
+source_code_url: "https://github.com/draftmark-app/draftmark"
+description: "Share markdown documents via a link and collect comments, reactions, and reviews from humans or AI agents, with a REST API to feed responses back into automated workflows (alternative to GitHub Gist, HackMD)."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Pastebins
+  - Knowledge Management Tools


### PR DESCRIPTION
Adding **Draftmark** — a self-hostable platform for sharing markdown documents via a link and collecting comments, reactions, and reviews (from humans or AI agents), with a REST API to feed responses back into automated workflows.

- Website / demo: https://draftmark.app
- Source: https://github.com/draftmark-app/draftmark
- License: MIT
- Platforms: Node.js, Docker
- First release: v1.0.0 (tagged); project first committed March 2026

Adds `software/draftmark.yml`. I've checked the description length (<250, sentence case), and validated the tag/platform/license values against the controlled lists.