### PR TITLE
Add InsForge

### DIFF
--- a/software/insforge.yml
+++ b/software/insforge.yml
@@ -1,0 +1,10 @@
+name: InsForge
+website_url: https://insforge.dev
+description: Backend server with a database, authentication, file storage, and a model gateway, built for AI coding agents to operate end to end.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+tags:
+  - Software Development - Low Code
+source_code_url: https://github.com/InsForge/InsForge

--- a/software/insforge.yml
+++ b/software/insforge.yml
@@ -1,6 +1,6 @@
 name: InsForge
 website_url: https://insforge.dev
-description: Backend server with a database, authentication, file storage, and a model gateway, built for AI coding agents to operate end to end.
+description: Backend server with a Postgres database, authentication, storage, edge functions, realtime, vector search, payments, and a model gateway, built for AI coding agents to operate end to end.
 licenses:
   - Apache-2.0
 platforms:


### PR DESCRIPTION
Adds InsForge, an Apache-2.0 licensed backend server (PostgreSQL database, authentication, file storage, model gateway) that self-hosts via Docker.

Tagged **Software Development - Low Code**, alongside comparable self-hostable backends already in the list (Appwrite, PocketBase).

- License: Apache-2.0
- Source: https://github.com/InsForge/InsForge
- Self-host: Docker
- First released 2025-09 (>4 months ago), actively maintained.

Metadata-only fields included; stargazers/commit history left for the bot to populate. One item in this PR.