### PR TITLE
add Spwig

### DIFF
--- a/software/spwig.yml
+++ b/software/spwig.yml
@@ -1,0 +1,12 @@
+name: Spwig
+website_url: https://spwig.com/
+source_code_url: https://github.com/Spwig/commerce
+description: E-commerce platform built on Django. Full ownership of code, data, and customers with one-line Docker install on any VPS with 2GB RAM.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - E-commerce
+depends_3rdparty: false


### PR DESCRIPTION
Adds Spwig to the E-commerce tag.

Spwig is a self-hosted e-commerce platform released under AGPL-3.0. Merchants own the code, data, and customers; one-line Docker install runs on any VPS with 2GB RAM. First public release (v1.5.7) was 2026-07-08.

Followed CONTRIBUTING.md: file is at software/spwig.yml (kebab-case), all mandatory fields populated, licenses uses SPDX identifier from licenses.yml, platforms + tags reference existing entries. depends_3rdparty=false since Spwig runs entirely on the merchant's own infrastructure with self-hostable PostgreSQL / Redis / S3-compatible storage.
