### PR TITLE
add Crawlee Cloud

### DIFF
--- a/software/crawlee-cloud.yml
+++ b/software/crawlee-cloud.yml
@@ -1,0 +1,11 @@
+name: Crawlee Cloud
+website_url: https://crawlee.cloud
+source_code_url: https://github.com/crawlee-cloud/crawlee-cloud
+description: Run web-scraping actors on your own infrastructure through an Apify-SDK-compatible API, with a monitoring dashboard, container-based execution, scheduling, webhooks and per-run cost reporting. (alternative to Apify)
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Automation


### PR DESCRIPTION
Adds Crawlee Cloud, a platform for running web-scraping actors on your own infrastructure via an Apify-SDK-compatible API (dashboard, container-based runner, scheduling, webhooks, per-run cost reporting).

Guideline checklist:
- [x] Software can be self-hosted and is primarily used for self-hosting
- [x] Free/open-source software license (MIT, in `licenses.yml`)
- [x] First released more than 4 months ago (v0.1.0, 2025-12-26; latest v1.4.0)
- [x] Tagged releases present (v0.1.0 through v1.4.0)
- [x] `platforms` (Nodejs, Docker) and `licenses` (MIT) reference existing entries
- [x] Single entry, one tag (`Automation`, mirroring similar web-scraping tools)
- [x] Description under 250 chars, sentence case, no redundant terms

Source: https://github.com/crawlee-cloud/crawlee-cloud · Website: https://crawlee.cloud