### PR TITLE
Add CrawlSEO

### DIFF
--- a/software/crawlseo.yml
+++ b/software/crawlseo.yml
@@ -1,0 +1,11 @@
+name: CrawlSEO
+website_url: https://github.com/crawlseo/crawlseo
+source_code_url: https://github.com/crawlseo/crawlseo
+description: SEO monitoring dashboard with Google Search Console analytics, site crawler, Core Web Vitals tracking, and MCP server for AI agents.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Analytics


### PR DESCRIPTION
Adding CrawlSEO — an open-source, self-hosted SEO monitoring dashboard.

- **Website/Source:** https://github.com/crawlseo/crawlseo
- **License:** MIT
- **Platforms:** Nodejs, Docker
- **Tag:** Analytics

CrawlSEO connects to Google Search Console and provides keyword/page analytics, a site crawler (up to 2,000 pages, 16 issue types), Core Web Vitals monitoring, SEO opportunity detection, alerts, and an MCP server with 10 tools for AI agent integration. Deployed via Docker Compose.