### PR TITLE
Add freehire

### DIFF
--- a/software/freehire.yml
+++ b/software/freehire.yml
@@ -1,0 +1,10 @@
+name: freehire
+website_url: https://freehire.dev/
+source_code_url: https://github.com/strelov1/freehire
+description: Search engine that aggregates and deduplicates tech job postings from many company ATS boards, served over a free public API.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - Human Resources Management (HRM)


### PR DESCRIPTION
Adds **freehire** — a self-hostable, open-source (MIT) search engine for jobs.

- Website: https://freehire.dev/
- Source: https://github.com/strelov1/freehire
- Self-hostable: Go backend + PostgreSQL + Meilisearch, Docker Compose.
- Aggregates and deduplicates job postings crawled straight from company ATS boards, served over a free public API.

Tagged under **Human Resources Management (HRM)** as the closest existing category (recruiting / job sourcing).