### PR TITLE
Add wellnizz and Open Wearables

### DIFF
--- a/software/open-wearables.yml
+++ b/software/open-wearables.yml
@@ -1,0 +1,11 @@
+name: Open Wearables
+website_url: https://github.com/the-momentum/open-wearables
+source_code_url: https://github.com/the-momentum/open-wearables
+description: Agent-native wearable data unification from WHOOP, Oura, Garmin, Suunto, Polar, Fitbit, Strava, plus Apple HealthKit, Samsung Health, Google Health Connect. FastAPI + MCP.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Health and Fitness

--- a/software/wellnizz.yml
+++ b/software/wellnizz.yml
@@ -1,0 +1,11 @@
+name: wellnizz
+website_url: https://github.com/liveforeverbetter/wellnizz
+source_code_url: https://github.com/liveforeverbetter/wellnizz
+description: Agent-native health API combining wearables (WHOOP, Oura, Garmin), 168+ biomarkers, and WGS genomics (ClinVar, CPIC, PRS). REST + MCP endpoints.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Health and Fitness


### PR DESCRIPTION
Add two self-hosted health/fitness platforms to the Health and Fitness section:

- **wellnizz** – Agent-native health API combining wearables (WHOOP, Oura, Garmin), 168+ biomarkers, and WGS genomics (ClinVar, CPIC, PRS). REST + MCP endpoints. Node.js/Docker. AGPL-3.0.
- **Open Wearables** – Agent-native wearable data unification from WHOOP, Oura, Garmin, Suunto, Polar, Fitbit, Strava, plus Apple HealthKit, Samsung Health, Google Health Connect. FastAPI + MCP. Python/Docker. MIT.