### PR TITLE
Add Apstal to Analytics

### DIFF
--- a/software/apstal.yml
+++ b/software/apstal.yml
@@ -1,0 +1,12 @@
+name: "Apstal"
+website_url: "https://apstal.com"
+description: "AI-first web analytics with session replay, heatmaps, funnels, and conversational AI queries."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Analytics
+source_code_url: "https://github.com/apstal/apstal-prod"
+demo_url: "https://apstal.com/app"


### PR DESCRIPTION
Add [Apstal](https://apstal.com) - AI-first web analytics with session replay, heatmaps, funnels, and conversational AI queries.

### ?? Self-Check

- [x] I have searched the repository for any relevant issues or PRs, including closed ones.
- [x] The software project was first released more than 4 months ago.
- [x] The software project has working installation instructions.
- [x] The software is actively maintained. ([Source Code](https://github.com/apstal/apstal-prod))