### PR TITLE
Add Another S3 Manager

### DIFF
--- a/software/another-s3-manager.yml
+++ b/software/another-s3-manager.yml
@@ -1,0 +1,11 @@
+name: Another S3 Manager
+website_url: https://github.com/kruchenburger/another-s3-manager
+description: 'Web UI for managing files across S3-compatible storage providers (AWS S3, MinIO, Cloudflare R2, Wasabi), with multi-user accounts, per-bucket permissions, and an MCP server that gives AI agents the same permissions as the logged-in user.'
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Python
+tags:
+  - File Transfer - Web-based File Managers
+source_code_url: https://github.com/kruchenburger/another-s3-manager


### PR DESCRIPTION
Adds Another S3 Manager — a web-based file manager for S3-compatible storage (AWS S3, MinIO, Cloudflare R2, Wasabi).

- License: MIT
- First public release: 2025-11-11 (older than 4 months)
- Actively maintained, current release v1.1.4
- Docs: https://github.com/kruchenburger/another-s3-manager#readme
- Tagged *File Transfer - Web-based File Managers*, same as Filestash.

`make awesome_lint` passes locally.
