### PR TITLE
add RelayTV

### DIFF
--- a/software/relaytv.yml
+++ b/software/relaytv.yml
@@ -1,0 +1,13 @@
+name: RelayTV
+website_url: https://relaytv.app
+description: Turns a Linux box connected to a television into a local playback endpoint. Send links from a phone, browse Jellyfin or Emby libraries, play IPTV channels, and drive playback from Home Assistant or HTTP (alternative to Chromecast).
+licenses:
+  - GPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Media Streaming - Multimedia Streaming
+  - Media Streaming - Video Streaming
+source_code_url: https://github.com/mcgeezy/relaytv
+related_software_url: https://github.com/mcgeezy/relaytv-android


### PR DESCRIPTION
Adds [RelayTV](https://github.com/mcgeezy/relaytv), a local-first playback endpoint for a Linux box connected to a television — send links from a phone, browse Jellyfin/Emby, play IPTV channels, and drive playback from Home Assistant or plain HTTP.

**Opened as a draft on purpose.** RelayTV's first tagged release (`v0.2.0`) was published on 2026-06-28, so it does not yet meet the _"first released more than 4 months ago"_ guideline. That threshold is reached on **2026-10-28**, and I'll mark this ready for review then. Tracking issue: #2786

Filed under `Media Streaming - Multimedia Streaming` as the first tag (alongside NymphCast, Kodi, Jellyfin), with `Media Streaming - Video Streaming` second for the live/IPTV side. `make awesome_lint` passes.

Disclosure: I'm the author of RelayTV.

---

- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [ ] Any software project you are adding was first released more than 4 months ago. — **not yet; eligible 2026-10-28, see above**
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.
