### PR TITLE
add Caspian

### DIFF
--- a/software/caspian.yml
+++ b/software/caspian.yml
@@ -1,0 +1,11 @@
+name: Caspian
+website_url: https://trycaspianai.com
+description: Communication gateway that gives AI agents one identity across Slack, Discord, Telegram, WhatsApp, email, SMS and X - one message handler, per-channel adapters with webhook signature verification, and Python/TypeScript SDKs.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Communication - Custom Communication Systems
+source_code_url: https://github.com/TryCaspian/caspian-sdk


### PR DESCRIPTION
Adds Caspian — a self-hostable communication gateway that gives AI agents one identity across Slack, Discord, Telegram, WhatsApp, email, SMS and X, behind a single message handler. FastAPI server with per-channel adapters (webhook signature verification, offline test fakes), deployable with `docker compose up`, plus Python and TypeScript SDKs and a CLI. AGPL-3.0.

- Source: https://github.com/TryCaspian/caspian-sdk
- Self-hosting docs: https://github.com/TryCaspian/caspian-sdk#self-hosting
- Disclosure: I'm one of the authors.