### PR TITLE
Add Communication - Email - Security & Reporting tag with four projects

### DIFF
--- a/software/dmarc-analyzer.yml
+++ b/software/dmarc-analyzer.yml
@@ -1,0 +1,11 @@
+name: DMARC Analyzer
+website_url: https://dmarc-analyzer.net
+source_code_url: https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp
+description: Collects DMARC aggregate reports from an IMAP mailbox and turns them into per-domain dashboards, with alerting, retention policies and multi-tenant separation for managing many clients.
+licenses:
+  - Apache-2.0
+platforms:
+  - Docker
+  - .NET
+tags:
+  - Communication - Email - Security & Reporting

--- a/software/dmarc-report-converter.yml
+++ b/software/dmarc-report-converter.yml
@@ -1,0 +1,10 @@
+name: dmarc-report-converter
+website_url: https://github.com/tierpod/dmarc-report-converter
+source_code_url: https://github.com/tierpod/dmarc-report-converter
+description: Command-line tool that reads DMARC aggregate report files from a local filesystem or an IMAP server and converts the XML into human-readable HTML, TXT or JSON output.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - Communication - Email - Security & Reporting

--- a/software/dmarc-report-viewer.yml
+++ b/software/dmarc-report-viewer.yml
@@ -1,0 +1,11 @@
+name: DMARC Report Viewer
+website_url: https://github.com/cry-inc/dmarc-report-viewer
+source_code_url: https://github.com/cry-inc/dmarc-report-viewer
+description: Standalone viewer for DMARC and SMTP TLS reports with a built-in IMAP client and web interface. Ships as a single binary or small container and keeps no database, reading the mailbox on each run.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Communication - Email - Security & Reporting

--- a/software/parsedmarc.yml
+++ b/software/parsedmarc.yml
@@ -1,0 +1,11 @@
+name: parsedmarc
+website_url: https://domainaware.github.io/parsedmarc/
+source_code_url: https://github.com/domainaware/parsedmarc
+description: Python package and CLI for parsing aggregate and forensic DMARC reports, with output to Elasticsearch, OpenSearch, Splunk or Kafka for dashboards built in Kibana or Grafana.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Communication - Email - Security & Reporting

--- a/tags/communication---email---security--reporting.yml
+++ b/tags/communication---email---security--reporting.yml
@@ -1,0 +1,5 @@
+name: Communication - Email - Security & Reporting
+description: 'Software for analysing [DMARC](https://en.wikipedia.org/wiki/DMARC), [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework) and [DKIM](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail) reports and monitoring the authentication of mail sent from your domains. These tools consume the aggregate reports that receiving providers send back; they do not send or receive mail themselves.'
+related_tags:
+  - Communication - Email - Complete Solutions
+  - Communication - Email - Mail Transfer Agents


### PR DESCRIPTION
**Disclosure first:** I maintain one of the four projects below (DMARC Analyzer). The other three are unaffiliated, and their descriptions are taken from their own READMEs. Happy to drop mine from this PR and add just the category plus the other three if you'd prefer the addition without the self-interest.

### Why a new tag

DMARC report analysis has no home in the list today. Searching the data for "dmarc" returns exactly two hits — Mox and Maddy — and in both cases it's a *feature* of a full mail server, not the subject. The tools that actually consume the aggregate reports receiving providers send back aren't listed at all.

They don't fit the existing categories either:

- **Communication - Email - Complete Solutions** is mail servers. These tools send and receive no mail.
- **Monitoring & Status Pages** has `redirect:` set, so nothing can reference it.
- **Analytics** is web analytics in practice.

Per CONTRIBUTING a tag needs three projects; this seeds it with four.

### What's included

| Project | Language | License |
|---|---|---|
| parsedmarc | Python | Apache-2.0 |
| DMARC Report Viewer | Rust | MIT |
| dmarc-report-converter | Go | MIT |
| DMARC Analyzer | .NET | Apache-2.0 |

All four are FOSS, self-hostable, actively developed and currently working. parsedmarc (1.2k★) is the best known; the two smaller ones (338★ and 278★) are established and maintained.

### Naming

`Communication - Email - Security & Reporting` follows the existing `Communication - Email - *` family so it nests with the other email categories rather than sitting on its own. Happy to rename — `DMARC & Email Reporting` or similar — if you'd rather it read differently.

`make awesome_lint` passes with no errors. The four warnings in my run are pre-existing entries with stale update dates, unrelated to this change.