### PR TITLE
add TrainingGeeks

### DIFF
--- a/software/traininggeeks.yml
+++ b/software/traininggeeks.yml
@@ -1,0 +1,11 @@
+name: TrainingGeeks
+website_url: https://traininggeeks.net
+source_code_url: https://github.com/arin-jaff/TrainingGeeks
+description: Training log and analytics for endurance and strength athletes. Calendar, performance management chart (CTL/ATL/TSB), zones, peak performances, FIT import and structured workout export to Garmin watches. (alternative to TrainingPeaks)
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+tags:
+  - Health and Fitness
+demo_url: https://demo.traininggeeks.net


### PR DESCRIPTION
Adds TrainingGeeks, a training log and analytics app for endurance and strength athletes.

- Source: https://github.com/arin-jaff/TrainingGeeks
- Demo: https://demo.traininggeeks.net (read-only, live instance of MY training data)
- License: AGPL-3.0
- Platform: Nodejs (Next.js, SQLite single-file database)
- Tag: Health and Fitness

Runs entirely on the user's own machine with no external account or service required. The intervals.icu and Strava connectors are optional and opt-in, but very helpful for connecting live fitness data

I am the author of the project!

First proper release I got to a publishable state was tagged 2026-06-08, so this is short of the four-month minimum. Can absolutely resubmit after the full 4 months!