### PR TITLE
add AppRankly

### DIFF
--- a/software/apprankly.yml
+++ b/software/apprankly.yml
@@ -1,0 +1,12 @@
+name: AppRankly
+website_url: https://github.com/zmsp/AppRankly
+source_code_url: https://github.com/zmsp/AppRankly
+description: Mobile app store analytics and ASO dashboard for iOS App Store Connect and Google Play Console.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Analytics
+demo_url: https://zmsp.github.io/AppRankly/#demo


### PR DESCRIPTION
Adds AppRankly (`software/apprankly.yml`) under Analytics. AppRankly is an open-source, self-hosted dashboard for mobile app store analytics (App Store Connect & Google Play Console) with built-in ASO keyword tools.