### PR TITLE
Add Pho: mobile photo sync to self-hosted SMB/WebDAV/NFS storage

### DIFF
--- a/software/pho.yml
+++ b/software/pho.yml
@@ -1,0 +1,10 @@
+name: Pho
+website_url: https://pho.tools
+description: Mobile photo gallery with sync to SMB, WebDAV and NFS storage, no server required (alternative to Google Photos).
+licenses:
+  - GPL-3.0
+platforms:
+  - Go
+tags:
+  - Photo Galleries
+source_code_url: https://github.com/fregie/pho


### PR DESCRIPTION
Add [Pho](https://github.com/fregie/pho).

**Software:** Native mobile photo gallery with sync to SMB, WebDAV and NFS storage. Go backend embedded in Flutter client (no standalone server). GPL-3.0 licensed.

**Note on scope:** Pho works by connecting to storage you already self-host (NAS, SMB share, etc.), rather than being a self-hosted application itself. Submitting here because (a) there is strong demand in the self-hosted community for serverless photo sync, and (b) it is already listed in neighboring lists like [foss_photo_libraries](https://github.com/meichthys/foss_photo_libraries). If this is out of scope, that's totally understandable — just let me know.