### PR TITLE
Add Lynavo Drive

### DIFF
--- a/software/lynavo-drive.yml
+++ b/software/lynavo-drive.yml
@@ -1,0 +1,12 @@
+name: Lynavo Drive
+website_url: https://drive.lynavo.io/
+description: High-performance local-LAN incremental media sync from iOS and Android to macOS and Windows (alternative to iCloud, Google Photos).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Go
+tags:
+  - File Transfer & Synchronization
+  - Photo Galleries
+source_code_url: https://github.com/Lynavo/lynavo-drive


### PR DESCRIPTION
## Summary

Adds Lynavo Drive, **An open-source alternative to iCloud and Google Photos**.

Lynavo Drive provides automatic incremental photo and video sync from iOS and Android to macOS and Windows over the local LAN. The AGPL-3.0 repository includes the desktop receiver, mobile clients, local discovery and pairing, resumable transfers, and source-build instructions.

The first tagged release was v0.1.0 on April 15, 2024; the current release is v1.0.1. The open-source edition is intentionally limited to foreground LAN sync and does not include remote access, cloud relay, official signed installers, or mobile store builds.

Disclosure: I am affiliated with the Lynavo Drive project.

### Checklist

- [x] Submit one item per pull request.
- [x] Searched existing issues and PRs, including closed ones.
- [x] Confirmed the project is not already listed in awesome-selfhosted-data or awesome-sysadmin.
- [x] The new file follows the addition template and uses kebab-case.
- [x] Platform values match the install and build requirements.
- [x] The project is actively maintained.
- [x] The first tagged release is more than four months old.
- [x] Working source-build instructions are available in the project README.
- [x] No demo URL or unused optional fields are included.