### PR TITLE
add DevOpsForge

### DIFF
--- a/software/devopsforge.yml
+++ b/software/devopsforge.yml
@@ -1,0 +1,8 @@
+name: DevOpsForge
+description: Interactive visual configuration generator for Docker Compose, Dockerfiles, and reverse proxies.
+website: https://devops-config-generator.vercel.app/
+source_code: https://github.com/Gohar01/devops-config-generator
+license: MIT
+language: JavaScript
+tags:
+  - Software Development - IDE & Tools


### PR DESCRIPTION
Added DevOpsForge to the dataset. It is a 100% client-side visual Docker Compose, Dockerfile, and reverse-proxy configuration builder.
- License: MIT
- Language: JavaScript
- Category: Software Development - IDE & Tools