### PR TITLE
add valheim-proxmox

### DIFF
--- a/software/valheim-proxmox.yml
+++ b/software/valheim-proxmox.yml
@@ -1,0 +1,11 @@
+name: valheim-proxmox
+website_url: https://github.com/PawelSzymanski89/valheim-proxmox
+source_code_url: https://github.com/PawelSzymanski89/valheim-proxmox
+description: Valheim dedicated server for Proxmox VE, installed into an LXC by one command, with a web panel for players, bans, worlds, backups and mods.
+licenses:
+  - MIT
+platforms:
+  - Bash
+  - Python
+tags:
+  - Games - Administrative Utilities & Control Panels


### PR DESCRIPTION
Valheim dedicated server for Proxmox VE with a self-hosted web panel: players and login history, bans and admin lists, worlds, backups, launch settings, and mods installed from a Thunderstore share code.

MIT, source on GitHub, releases published. I am the author.

Tagged under Games - Administrative Utilities & Control Panels, next to GameAP and Pterodactyl.