### PR TITLE
Add Windshift

### DIFF
--- a/software/windshift.yml
+++ b/software/windshift.yml
@@ -1,0 +1,10 @@
+name: Windshift
+website_url: https://windshift.sh/
+source_code_url: https://github.com/Windshiftapp/core
+description: Work management with boards, backlogs, sprints and roadmaps (alternative to Jira).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+tags:
+  - Software Development - Project Management


### PR DESCRIPTION
Windshift is self-hosted work management with boards, backlogs, sprints and roadmaps, written in Go and licensed AGPL-3.0.

Website: https://windshift.sh
Source: https://github.com/Windshiftapp/core

First release (v0.4.2) was published 2026-03-31, so it is past the 4 month mark. `make awesome_lint` passes locally.