### PR TITLE
Add Wolfpack

### DIFF
--- a/software/wolfpack.yml
+++ b/software/wolfpack.yml
@@ -1,0 +1,11 @@
+name: Wolfpack
+website_url: https://github.com/almogdepaz/wolfpack
+description: Browser and mobile control center for persistent AI coding-agent and shell sessions across machines, with private remote access over Tailscale.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Nodejs
+tags:
+  - Remote Access
+source_code_url: https://github.com/almogdepaz/wolfpack


### PR DESCRIPTION
Wolfpack is a browser and mobile control center for persistent AI coding-agent and shell sessions across machines, with private remote access over Tailscale.

- MIT licensed
- Rust broker and Nodejs/Bun server
- First release was published more than four months ago
- Installation instructions: https://github.com/almogdepaz/wolfpack#installation
- Active development and recent releases

The Remote Access category is the best fit because Wolfpack provides remote browser/mobile control of terminal sessions on machines the user owns.