### PR TITLE
Add OpenJornada

### DIFF
--- a/software/openjornada.yml
+++ b/software/openjornada.yml
@@ -1,0 +1,12 @@
+name: OpenJornada
+website_url: https://www.openjornada.es/
+source_code_url: https://github.com/openjornada/openjornada-api
+description: Employee time and attendance tracking for Spanish/EU labor-law compliance (RD-Ley 8/2019): clock in/out, immutable records, digital signatures, PDF/CSV reports for labor inspection and SMS reminders. (alternative to Factorial, Sesame HR)
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Nodejs
+  - Docker
+tags:
+  - Time Tracking


### PR DESCRIPTION
Adds **OpenJornada**, an employee time & attendance tracker focused on Spanish/EU labor-law compliance (RD-Ley 8/2019).

Checklist:
- [x] One item per PR
- [x] Free and Open-Source (AGPL-3.0)
- [x] First released more than 4 months ago (initial release December 2025)
- [x] Tagged releases and active maintenance (see `openjornada-api`, `openjornada-admin`, `openjornada-trabajadores`)
- [x] Installation documentation available (Docker / docker-compose in the source repository README)
- [x] Not a duplicate; no existing entry for OpenJornada

Category: **Time Tracking**. Deployable via Docker (FastAPI/Python API + Next.js admin + PWA worker app + MongoDB).