### PR TITLE
Add MyNeS

### DIFF
--- a/software/mynes.yml
+++ b/software/mynes.yml
@@ -1,0 +1,12 @@
+name: MyNeS
+website_url: https://github.com/fxerkan/my_network_scanner
+description: Scans a LAN over ARP, mDNS, SSDP, Matter, Bluetooth LE and MQTT, so Zigbee and Z-Wave devices without an IP address are inventoried too. Alerts on new or missing devices and syncs both ways with Home Assistant.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Network Utilities
+  - Internet of Things (IoT)
+source_code_url: https://github.com/fxerkan/my_network_scanner


### PR DESCRIPTION
Adds **MyNeS (My Network Scanner)**: a self-hosted LAN scanner and device inventory.

- Source and homepage: https://github.com/fxerkan/my_network_scanner
- License: MIT
- Platforms: Python, Docker (multi-arch `amd64` + `arm64`)
- Tags: Network Utilities, Internet of Things (IoT)

## Why it is not just another nmap wrapper

It discovers devices over ARP, mDNS/Bonjour, SSDP/UPnP, Matter, Bluetooth LE **and MQTT**. The MQTT part is the reason the project exists: reading retained Zigbee2MQTT / Z-Wave JS / Tasmota topics is the only way to inventory a radio device that has no IP address at all, so Zigbee bulbs and Z-Wave sensors land in the same list as the laptops. It also does rule-based alerting on new / missing / changed devices, and two-way Home Assistant integration (MQTT Discovery push, REST/WebSocket pull and diff).

## Against the inclusion criteria

- **Age:** first release July 2025, so well over the 4-month minimum. Actively maintained; latest release v1.3.0 today.
- **Self-hostable:** yes, entirely. No cloud, no account, no telemetry, no third-party service required at runtime.
- **License:** MIT, `LICENSE` at repo root.
- **Documentation:** README in English and Turkish, `SECURITY.md`, deployment docs, screenshots in the README.
- **No demo instance** — it is a network scanner; a public demo would either show my own LAN or show nothing. Screenshots are in the README instead. Happy to add `demo_url` if a mock instance would help.
- **Not a fork or a thin wrapper.**

`depends_3rdparty` is not set: optional integrations (MQTT broker, Home Assistant) are additive, and the app scans with zero configuration and no external service.