### PR TITLE
Add BitFun Relay Server

### DIFF
--- a/software/bitfun-relay-server.yml
+++ b/software/bitfun-relay-server.yml
@@ -1,0 +1,11 @@
+name: BitFun Relay Server
+website_url: https://github.com/GCWing/BitFun/tree/main/src/apps/relay-server
+description: WebSocket and HTTP relay for remote device control, account login, and cross-device session sync. Clients encrypt locally, so the server stores no plaintext credentials or readable sync payloads.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Rust
+tags:
+  - Remote Access
+source_code_url: https://github.com/GCWing/BitFun


### PR DESCRIPTION
Adds `software/bitfun-relay-server.yml`.

BitFun Relay Server is a WebSocket/HTTP relay that provides account login, cross-device session and settings sync, and Peer Device Mode (controlling another online device on the same account). It is zero-knowledge by design: clients derive a master key locally, and the server stores Argon2id password hashes and AES-GCM-wrapped keys — never plaintext passwords or decryptable sync payloads.

**Disclosure up front, so it does not waste reviewer time:** this relay lives in the `src/apps/relay-server/` directory of the BitFun monorepo, whose primary artifact is a desktop application. The desktop app itself does *not* qualify for this list, and I am not submitting it. The relay is submitted on its own because it is a server-side network service that the user deploys and operates. If maintainers consider a component of a larger repository out of scope, I understand — please close it.

Why it qualifies on its own terms:

- **It must be self-hosted to exist at all.** Upstream ships no public hosted instance. The project README opens with: *"Open-source BitFun does not ship a public hosted login service. If you want Desktop / CLI account login, cross-device session & settings sync, or Peer Device Mode, you must: 1. Deploy this relay yourself."* Without a self-hosted relay these features are simply unavailable.
- **Working installation instructions**: a 634-line [README](https://github.com/GCWing/BitFun/tree/main/src/apps/relay-server) covering one-command `bash deploy.sh` Docker deployment, a supported-host matrix (Linux amd64 / arm64), `docker-compose.yml`, `Dockerfile`, a Caddyfile, and start/stop/restart scripts. Accounts are provisioned out-of-band via `relay-admin`; there is no public sign-up.
- **No dependency on a specific cloud provider.** Deploys to any Docker host.
- **Not a library or SDK** — it is a running service, no application code required from the operator.
- **Age and maintenance**: the project's first release was v0.1.0 on 2026-02-09 (~6 months ago), with 25 releases since, the latest v0.2.15 on 2026-07-31.
- MIT licensed.

Checklist:

- [x] Submit one item per pull request.
- [x] Searched the repository for relevant issues and PRs, including closed ones — no prior BitFun submission exists.
- [x] Not already listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io.
- [x] Formatted as described in `addition.md`; kebab-case filename; comments and unused optional fields removed.
- [x] No `Demo` link — there is no hosted interactive demo, by design.
- [x] `platforms` reflects what is needed to install and run it (Docker; Rust for source builds).
- [x] Actively maintained.
- [x] First released more than 4 months ago.
- [x] Has working installation instructions.
- [x] I understand the PR will be merged at least ~1 week after approval.