### PR TITLE
Add BombVault

### DIFF
--- a/software/bombvault.yml
+++ b/software/bombvault.yml
@@ -1,0 +1,11 @@
+name: BombVault
+website_url: https://junkerderprovinz.github.io/bombvault/
+source_code_url: https://github.com/junkerderprovinz/bombvault
+description: One-click backup and full disaster recovery for Unraid servers - Docker containers, KVM VMs, appdata and the USB flash config - with deduplicated, encrypted, incremental off-site copies via restic.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+  - Go
+tags:
+  - Backup


### PR DESCRIPTION
Adds **BombVault**, a free and open-source (AGPL-3.0) self-hosted backup and disaster-recovery tool.

- Backs up Docker containers, KVM VMs, appdata, arbitrary files and the host config, and restores them in one click.
- Storage engine is restic (deduplicated, incremental, always encrypted); off-site copies go to sftp or S3-compatible targets.
- Runs as a container; no account, no telemetry.
- Source + docs: https://github.com/junkerderprovinz/bombvault

Category: Backup. Please let me know if anything in the entry needs adjusting.
