### PR TITLE
add CloakBin

### DIFF
--- a/software/cloakbin.yml
+++ b/software/cloakbin.yml
@@ -1,0 +1,11 @@
+name: CloakBin
+website_url: https://oss.cloakbin.com
+description: Zero-knowledge encrypted pastebin, where text is encrypted in the browser with AES-256-GCM before upload and the key is kept in the URL fragment, so the server only ever stores ciphertext.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+tags:
+  - Pastebins
+source_code_url: https://github.com/Ishannaik/CloakBin
+demo_url: https://oss.cloakbin.com


### PR DESCRIPTION
Adding [CloakBin](https://github.com/Ishannaik/CloakBin), a zero-knowledge encrypted pastebin. Text is encrypted in the browser with AES-256-GCM before upload, and the key lives in the URL fragment (never sent to the server), so the server only ever stores ciphertext.

Live instance / demo: https://oss.cloakbin.com

Checklist:
- [x] One item per PR.
- [x] Searched existing issues and PRs, including closed ones — no prior entry for CloakBin.
- [x] Not already listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io.
- [x] Actively maintained (regular commits, 2 releases).
- [x] First released more than 4 months ago (v1.0.0 on 2026-03-16; repo created 2024-03-16).
- [x] Working installation instructions in the README (clone, `pnpm install`, configure `MONGODB_URI`, `pnpm dev`), plus a `/health` endpoint for orchestrators.

I'm the maintainer. Happy to adjust the tags, description, or platform list if anything doesn't match your conventions.