### PR TITLE
add OpenShorts

### DIFF
--- a/software/openshorts.yml
+++ b/software/openshorts.yml
@@ -1,0 +1,13 @@
+name: OpenShorts
+website_url: https://www.openshorts.app/
+source_code_url: https://github.com/mutonby/openshorts
+description: Turns long videos into vertical short clips, with AI moment detection, face tracking, word-level subtitles and dubbing. Exposes a REST API and an MCP server so agents can drive the pipeline.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Media Management
+depends_3rdparty: true


### PR DESCRIPTION
Adds OpenShorts, a self-hosted AI clip generator that turns long videos into vertical short clips.

- Website: https://www.openshorts.app/
- Source: https://github.com/mutonby/openshorts
- License: MIT (the `cloud/` directory, which only contains the hosted service's billing and metering code, is under a separate commercial licence; the self-hosted edition is fully functional under MIT)
- Install: Docker and Docker Compose, instructions in the README
- First released December 2025, actively maintained

`depends_3rdparty: true` because AI features require a Google Gemini API key (and optionally fal.ai / ElevenLabs), which the user supplies.

Checklist:
- [x] One item per PR
- [x] Searched existing issues and PRs
- [x] Not listed in awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me or dbdb.io
- [x] Actively maintained
- [x] First released more than 4 months ago
- [x] Working installation instructions