### PR TITLE
Add CompozyOS

### DIFF
--- a/software/compozyos.yml
+++ b/software/compozyos.yml
@@ -1,0 +1,11 @@
+name: CompozyOS
+website_url: https://www.compozy.com
+source_code_url: https://github.com/compozy/compozy
+description: Operating system for AI agents. Plug in the agent CLIs you already use and run them as a team on loops and schedules, with shared memory, permissions, approvals, and a web shell to supervise everything.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Software Development - IDE & Tools


### PR DESCRIPTION
CompozyOS is an open-source (MIT) operating system for AI agents. It runs the agent CLIs you already use as a team on loops and schedules, with shared project memory, scoped permissions, approvals and an audit trail, all supervised from a web shell. Single Go binary, SQLite-backed, local-first.

- Repo: https://github.com/compozy/compozy
- Site: https://www.compozy.com
- License: MIT

Added under **software/compozyos.yml**, following the section's existing ordering and format.
