### PR TITLE
Add SlackONOS

### DIFF
--- a/software/slackonos.yml
+++ b/software/slackonos.yml
@@ -1,0 +1,13 @@
+name: SlackONOS
+website_url: https://github.com/htilly/SlackONOS
+source_code_url: https://github.com/htilly/SlackONOS
+description: Chat-controlled Sonos speaker queue with Spotify search, vote-to-play and vote-to-skip for Slack and Discord.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Internet of Things (IoT)
+  - Media Streaming - Audio Streaming
+depends_3rdparty: true


### PR DESCRIPTION
Chat-controlled Sonos speaker queue for Slack and Discord, with
Spotify search and community vote-to-play / vote-to-skip ("gong").

- License: AGPL-3.0
- Actively maintained, first released 2016
- Depends on third-party services: Spotify (search/playback) and Slack/Discord (chat)
- Repo: https://github.com/htilly/SlackONOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>