### PR TITLE
Add Talon

### DIFF
--- a/software/talon.yml
+++ b/software/talon.yml
@@ -1,0 +1,13 @@
+name: "Talon"
+website_url: "https://talon-agent.github.io"
+source_code_url: "https://github.com/dylanneve1/talon"
+description: "Agentic AI harness for Telegram, Discord, Teams and the terminal, with pluggable model backends, MCP tool access, and background agents for goals, scheduled heartbeats and memory consolidation."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Automation
+depends_3rdparty: true


### PR DESCRIPTION
Talon is an MIT-licensed self-hosted agentic AI harness: it runs as a daemon you host yourself, connects to Telegram/Discord/Teams/terminal front-ends, and supports pluggable model backends plus MCP tools, scheduled background agents and persistent memory.

- Source: https://github.com/dylanneve1/talon
- Licence: MIT
- First release v1.1.0 published 2026-04-08 (>4 months ago)
- Deployable via Node.js or Docker

Entry added as software/talon.yml.