### PR TITLE
add terraform-provider-seerr

### DIFF
--- a/software/terraform-provider-seerr.yml
+++ b/software/terraform-provider-seerr.yml
@@ -1,0 +1,10 @@
+name: terraform-provider-seerr
+website_url: https://github.com/Josh-Archer/terraform-provider-seerr
+source_code_url: https://github.com/Josh-Archer/terraform-provider-seerr
+description: Terraform provider for Seerr (Overseerr/Jellyseerr) media request management.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - Automation


### PR DESCRIPTION
Adds [terraform-provider-seerr](https://github.com/Josh-Archer/terraform-provider-seerr) to awesome-selfhosted under Automation.