### PR TITLE
fix 1time.io source_code_url

### DIFF
--- a/software/1time.yml
+++ b/software/1time.yml
@@ -1,6 +1,6 @@
 name: 1time
 website_url: https://1time.io
-source_code_url: https://github.com/shingrus/1time
+source_code_url: https://github.com/shingrus/1time.io
 description: Zero-knowledge one-time secret sharing. Create a one-time link for a password, API key, or file. Encrypted client-side in the browser, never reaches the server in plaintext, self-destructs after the allowed number of views (one by default).
 licenses:
   - MIT


### PR DESCRIPTION
- ref: https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/31282579011/job/93166167644
- `repository not found in search results: https://github.com/shingrus/1time`
