### PR TITLE
add intentic

### DIFF
--- a/software/intentic.yml
+++ b/software/intentic.yml
@@ -1,0 +1,13 @@
+name: intentic
+website_url: https://intentic.dev
+source_code_url: https://github.com/intentic/intentic
+description: Workspace for running coding agents on hardware you own. Each agent gets a persistent container sandbox and a git worktree of its own, reached from any browser, and keeps working after you close the tab.
+licenses:
+  - MIT
+platforms:
+  - Docker
+  - Nodejs
+tags:
+  - Software Development - IDE & Tools
+depends_3rdparty: true
+demo_url: https://intentic.dev/demo/


### PR DESCRIPTION
Adds intentic — a self-hosted workspace for running coding agents on your own machine.

The sandbox daemon runs on hardware you own (Docker on a laptop, desktop or VPS) and holds the code, the credentials and the agent processes; every browser is a window onto it, and runs continue after you close the tab. Each agent gets its own container sandbox and git worktree, with plan mode, per-hunk diff review and an approvable environment Dockerfile.

`depends_3rdparty: true` is set and deliberate: sign-in and sandbox discovery go through a hosted identity tier at intentic.dev, while everything else — chat, terminals, files, diffs — is browser-to-your-machine over your own Cloudflare tunnel.

- Source: https://github.com/intentic/intentic (MIT)
- Live demo: https://intentic.dev/demo/
- Docs: https://intentic.dev/docs
