### PR TITLE
Add Tollgate and Gnom-Hub

### DIFF
--- a/software/gnom-hub.yml
+++ b/software/gnom-hub.yml
@@ -1,0 +1,14 @@
+name: Gnom-Hub
+website_url: https://landjunge.github.io/gnom-hub-v1/
+source_code_url: https://github.com/landjunge/gnom-hub-v1
+description: Local multi-agent control hub — brainstorm freely, run workers only when you press Execute. Visible agent desk, skills, tools, safe computer-use. No Docker required.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Automation
+depends_3rdparty: true
+demo_url: https://landjunge.github.io/gnom-hub-v1/
+related_software_url: https://github.com/landjunge/tollgate

--- a/software/tollgate.yml
+++ b/software/tollgate.yml
@@ -1,0 +1,15 @@
+name: Tollgate
+website_url: https://landjunge.github.io/tollgate/
+source_code_url: https://github.com/landjunge/tollgate
+description: Safety layer for AI agents (Protect · Route · Prove) — budgets, tool-loop hard stops, failover, chaos/DR proof, freeze, audit. OpenAI-compatible API, MCP, n8n.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Automation
+depends_3rdparty: true
+demo_url: https://landjunge.github.io/tollgate/
+related_software_url: https://github.com/landjunge/gnom-hub-v1


### PR DESCRIPTION
## Software

### Tollgate
- Safety layer for AI agents (Protect · Route · Prove)
- Source: https://github.com/landjunge/tollgate
- Site: https://landjunge.github.io/tollgate/
- License: MIT
- Platforms: Python, Docker

### Gnom-Hub  
- Local multi-agent control hub (brainstorm free, Execute on purpose)
- Source: https://github.com/landjunge/gnom-hub-v1
- Site: https://landjunge.github.io/gnom-hub-v1/
- License: MIT
- Platforms: Python (no Docker required)

Both are self-hostable, open source, local-first tools for agent workflows.