### PR TITLE
Add Houndarr

### DIFF
--- a/software/houndarr.yml
+++ b/software/houndarr.yml
@@ -1,0 +1,11 @@
+name: Houndarr
+website_url: https://av1155.github.io/houndarr/
+source_code_url: https://github.com/av1155/houndarr
+description: Scheduled backlog searches for Radarr, Sonarr, Lidarr, Readarr and Whisparr. Works through missing and cutoff-unmet items in small rate-limited batches with per-item cooldowns and hourly caps, to avoid overloading indexers.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Docker
+tags:
+  - Media Management


### PR DESCRIPTION
Thanks for taking the time to suggest an addition to awesome-selfhosted! 

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.

Houndarr sits alongside an existing \*arr stack and works through the backlog those apps do not revisit on their own. Radarr and Sonarr monitor RSS for new releases, so items already in the library that are missing or below the quality cutoff are only re-searched by hand, and the built-in "Search All Missing" button fires everything at once. Houndarr does the same work on a schedule in small batches, with per-item cooldowns and an hourly cap per instance.

First release was 14 March, currently on 1.13.2. It is tagged `Media Management` to match Radarr, Sonarr and Lidarr.