### PR TITLE
Add Sillage

### DIFF
--- a/software/sillage.yml
+++ b/software/sillage.yml
@@ -1,0 +1,11 @@
+name: Sillage
+website_url: https://marlburrow.github.io/sillage
+description: Mobile-first web UI that drives the native Claude Code and Codex CLIs running on your own machine, with sessions that outlive the client, full-text search across conversations, an IDE panel, and an installable PWA.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Software Development - IDE & Tools
+source_code_url: https://github.com/MarlBurroW/sillage


### PR DESCRIPTION
Adds `software/sillage.yml`.

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs running on your own machine. Sessions that outlive the client, full-text search across every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

- name: Sillage
- source_code_url: https://github.com/MarlBurroW/sillage
- license: MIT (OSI-approved)
- platforms: Nodejs, Docker
- tags: Software Development - IDE & Tools

Disclosure: I am the author of Sillage.