### PR TITLE
Add OxiPulse

### DIFF
--- a/software/oxi-pulse.yml
+++ b/software/oxi-pulse.yml
@@ -1,0 +1,10 @@
+name: OxiPulse
+website_url: https://github.com/securyblack/oxi-pulse
+source_code_url: https://github.com/securyblack/oxi-pulse
+description: Ultralight Rust monitoring agent shipping CPU, RAM, disk and network metrics to any OTLP-compatible backend.
+licenses:
+  - Apache-2.0
+platforms:
+  - Rust
+tags:
+  - Monitoring & Status Pages


### PR DESCRIPTION
Adding OxiPulse, an ultralight Rust monitoring agent that ships CPU/RAM/disk/network metrics via OTLP.

- First release: 2026-03-13 (>4 months old)
- License: Apache-2.0
- Not tied to a specific cloud provider — sends OTLP to any compatible backend (self-hosted collector, Grafana Cloud, or SecuryBlack Cloud)
- Repo: https://github.com/securyblack/oxi-pulse