### PR TITLE
add Awesome Tunneling to external links in VPN tag header

### DIFF
--- a/tags/vpn.yml
+++ b/tags/vpn.yml
@@ -3,3 +3,6 @@ description: A [virtual private network (VPN)](https://en.wikipedia.org/wiki/Vir
 redirect:
   - title: awesome-sysadmin/VPN
     url: https://github.com/awesome-foss/awesome-sysadmin#vpn
+external_links:
+  - title: Awesome-Tunneling
+    url: https://github.com/anderspitman/awesome-tunneling


### PR DESCRIPTION
This is a well maintained project which lists alternatives to ngrok (self-service reverse proxy, allows clients to expose their locally running services over a public subdomain). I used it recently (ended up setting up `pgrok` - example `pgrok http 8080` exposes the service running a laptop on 127.0.0.1:8080 as `https://mysuername.pgrok.mydomain.org`)

I havent added it to the `Any software you are adding is not already listed at any of...` list in the PR template/contribution guidelines because there is probably some overlap between both lists (it goes a bit into VPN territory).

However it is better suited to submissions such as this one https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/2901