### PR TITLE
add Ollama Herd software

### DIFF
--- a/software/ollama-herd.yml
+++ b/software/ollama-herd.yml
@@ -1,0 +1,10 @@
+name: Ollama Herd
+website_url: https://ollamaherd.com
+source_code_url: https://github.com/geeks-accelerator/ollama-herd
+description: Load-balances LLM inference, image generation, speech-to-text and embeddings across a fleet of machines. Discovers nodes over mDNS and scores each on memory, thermal state, queue depth and loaded models. OpenAI-, Ollama- and Anthropic-compatible.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
Adds [Ollama Herd](https://github.com/geeks-accelerator/ollama-herd), a self-hosted router that load-balances LLM inference (plus image generation, speech-to-text and embeddings) across a fleet of machines you already own.

It discovers nodes over mDNS with no config files, and scores each node on memory fit, thermal state, queue depth and which models are already loaded, so requests avoid cold-loading a model that is warm elsewhere. It serves OpenAI-, Ollama- and Anthropic-compatible APIs, so existing clients work by changing a base URL.

- MIT licensed, Python, `pip install ollama-herd`
- Actively developed; first released 2026-04-14, latest release v0.9.2 (2026-08-16)
- Runs entirely on your own hardware with no third-party service dependency