### PR TITLE
Add nandns

### DIFF
--- a/software/nandns.yml
+++ b/software/nandns.yml
@@ -1,0 +1,12 @@
+name: nandns
+website_url: https://github.com/nandezgarcia/nandns
+source_code_url: https://github.com/nandezgarcia/nandns
+description: "Self-hosted dynamic DNS (DDNS) service backed by the Cloudflare API, with a DuckDNS-compatible update endpoint and a free public instance."
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - DNS
+depends_3rdparty: true
+demo_url: https://dns.kiokao.com


### PR DESCRIPTION
Add [nandns](https://github.com/nandezgarcia/nandns), a self-hosted dynamic DNS (DDNS) service — a DuckDNS alternative built with FastAPI and the Cloudflare API.

- Public instance running in production since June 2026: https://dns.kiokao.com
- DuckDNS-compatible `/update` endpoint (works with routers and existing DDNS clients)
- Auto-update scripts for Windows/macOS/Linux, Google OAuth login, trilingual web UI (ES/EN/ZH)
- Installation instructions in the README (venv + uvicorn, or systemd)
- `depends_3rdparty: true` because it uses the Cloudflare API as DNS backend

Checklist:
- [x] Submit one item per pull request.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software you are adding is not already listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me or dbdb.io.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding has working installation instructions.
- Note: the service has been running in production since 2026-06-08; the public source repository was published on 2026-08-17 (it was private during initial development).