### PR TITLE
Update HomeButler (tags, description)

### DIFF
--- a/software/homebutler.yml
+++ b/software/homebutler.yml
@@ -1,6 +1,6 @@
 name: HomeButler
 website_url: https://homebutler.dev
-description: Installs and manages a curated catalog of applications via Docker Compose, maps containers and exposed ports, verifies backups restore, and reports what changed since the last run. Single Go binary with CLI, JSON, web and MCP interfaces.
+description: Installs and manages a curated catalog of applications via Docker Compose, maps containers and exposed ports, verifies backups restore, and reports what changed since the last run with CLI, JSON, web and MCP interfaces.
 licenses:
   - MIT
 platforms:

--- a/software/homebutler.yml
+++ b/software/homebutler.yml
@@ -1,6 +1,6 @@
 name: HomeButler
 website_url: https://homebutler.dev
-description: Installs and manages a curated catalog of applications (Jellyfin, Pi-hole, Gitea, Vaultwarden and more) via Docker Compose, maps containers and exposed ports, verifies backups restore, and reports what changed since the previous run. Single Go binary with terminal, JSON, web dashboard and MCP interfaces.
+description: Installs and manages a curated catalog of applications via Docker Compose, maps containers and exposed ports, verifies backups restore, and reports what changed since the last run. Single Go binary with CLI, JSON, web and MCP interfaces.
 licenses:
   - MIT
 platforms:

--- a/software/homebutler.yml
+++ b/software/homebutler.yml
@@ -1,12 +1,13 @@
 name: HomeButler
 website_url: https://homebutler.dev
-description: Homelab management tool for monitoring hosts, Docker services, Wake-on-LAN, inventory, and remote operations, with a web dashboard and MCP integrations.
+description: Installs and manages a curated catalog of applications (Jellyfin, Pi-hole, Gitea, Vaultwarden and more) via Docker Compose, maps containers and exposed ports, verifies backups restore, and reports what changed since the previous run. Single Go binary with terminal, JSON, web dashboard and MCP interfaces.
 licenses:
   - MIT
 platforms:
   - Docker
   - Go
 tags:
+  - Self-hosting Solutions
   - Automation
   - Remote Access
 source_code_url: https://github.com/Higangssh/homebutler


### PR DESCRIPTION
I maintain HomeButler, which is currently listed under `Automation`. Having watched where it actually lands in single page mode, I think that placement is doing readers a disservice, so I'd like to propose reordering its tags.

**Why `Self-hosting Solutions` fits better as the first tag**

Since single page mode only shows an entry under its first category, HomeButler currently appears between Huginn, Kestra, Kibitzr and gocron — workflow engines, schedulers and event-driven agents. It isn't one of those. It doesn't run user-defined workflows or react to triggers.

What it does do maps closely onto how `Self-hosting Solutions` is described ("easy installation, management and configuration of services and applications"): it installs a curated catalog of applications via Docker Compose, generates and owns their compose files, handles port conflict checks and lifecycle (`install` / `status` / `uninstall` / `purge`), and reports on them afterwards.

I'm keeping `Automation` and `Remote Access` — the restart-watch and multi-server pieces justify both — and only moving `Self-hosting Solutions` to the front so the single page entry lands somewhere a reader is looking for this kind of tool.

**Description**

The current description leads with "monitoring", which is misleading given `Monitoring & Status Pages` redirects to awesome-sysadmin. The proposed text describes the app installation and management side first, names the concrete apps, and mentions Go since the project distributes a single static binary, per the guidelines.

I've kept the change to `description` and `tags` only; the generated fields are untouched.
