### PR TITLE
Add LoopTroop

### DIFF
--- a/software/looptroop.yml
+++ b/software/looptroop.yml
@@ -1,0 +1,12 @@
+name: LoopTroop
+website_url: https://www.looptroop.ovh/
+source_code_url: https://github.com/looptroop-ai/LoopTroop
+description: Local GUI for planning and running long-running AI coding tasks across multiple repositories with LLM councils, isolated Git worktrees, and Ralph loops.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Generative Artificial Intelligence (GenAI)
+  - Software Development - IDE & Tools


### PR DESCRIPTION
## Summary

Adds LoopTroop to the software list.

LoopTroop is a local GUI for planning and running long-running AI coding tasks across multiple repositories with LLM councils, isolated Git worktrees, and Ralph loops.

- Homepage: https://www.looptroop.ovh/
- Source: https://github.com/looptroop-ai/LoopTroop
- License: MIT

## Checks

- `awesome_lint` completed successfully.
- `awesome_lint_strict` completed successfully; it reported only existing stale-project warnings.