### PR TITLE
Add Pakistan Mutual Funds API

### DIFF
--- a/software/pakistan-mutual-funds-api.yml
+++ b/software/pakistan-mutual-funds-api.yml
@@ -1,0 +1,10 @@
+name: Pakistan Mutual Funds API
+website_url: https://saadsalman.org/blog/free-api-pakistani-mutual-fund-navs
+source_code_url: https://github.com/saadsalmankhan/pakistan-mutual-funds-api
+description: REST API exposing current net asset values (NAVs) and offer prices for Pakistani mutual funds, sourced from MUFAP's public fund directory.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Money, Budgeting & Management


### PR DESCRIPTION
Adds **Pakistan Mutual Funds API**, a self-hostable REST API that serves current NAVs and offer prices for ~550 Pakistani mutual funds, scraped from MUFAP's public Fund Directory. Runs as a small Node.js/Express service that caches to a local JSON file, no database required.

- Source: https://github.com/saadsalmankhan/pakistan-mutual-funds-api
- License: MIT
- Platform: Nodejs
- Tag: Money, Budgeting & Management

I followed the software entry format (core fields only; metadata is bot-generated) and referenced existing tag/platform/license entries.

Note: the first tagged release (v1.0.0) is recent, so if this doesn't yet meet the 4-month maturity guideline I'm happy to resubmit once it does.