### PR TITLE
fix Pelican Panel source_code_url

### DIFF
--- a/software/pelican-panel.yml
+++ b/software/pelican-panel.yml
@@ -1,6 +1,6 @@
 name: Pelican Panel
 website_url: https://pelican.dev/
-source_code_url: https://github.com/pelican-dev/panel
+source_code_url: https://github.com/pelican/panel
 description: Web application for easy management of game servers, offering a user-friendly interface for deploying, configuring, and managing servers, server monitoring tools, and extensive customization options (fork of Pterodactyl).
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
- ref: #1 
- `ERROR:software_metadata.py: repository not found in search results: https://github.com/pelican-dev/panel`
- https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/32310185481/job/96251396495