### PR TITLE
Remove 3 dead-urls entries

### DIFF
--- a/software/bytebase.yml
+++ b/software/bytebase.yml
@@ -10,7 +10,6 @@ platforms:
 tags:
   - Database Management
 source_code_url: https://github.com/bytebase/bytebase
-demo_url: https://demo.bytebase.com
 stargazers_count: 14385
 updated_at: '2026-08-15'
 archived: false

--- a/software/canvas-lms.yml
+++ b/software/canvas-lms.yml
@@ -8,7 +8,6 @@ platforms:
 tags:
   - Learning and Courses
 source_code_url: https://github.com/instructure/canvas-lms
-demo_url: https://canvas.instructure.com/register
 stargazers_count: 6772
 updated_at: '2026-04-30'
 archived: false

--- a/software/managemeals.yml
+++ b/software/managemeals.yml
@@ -8,7 +8,6 @@ platforms:
   - Docker
 tags:
   - Recipe Management
-demo_url: https://demo.managemeals.com/
 stargazers_count: 61
 updated_at: '2026-06-01'
 archived: false


### PR DESCRIPTION
### Drop demo_url from Bytebase

* ref: #1
* `url_check: https://demo.bytebase.com — ConnectError: [Errno -2] Name or service not known, failing since 2026-08-15 (5 days, 3 checks)`

### Drop demo_url from Canvas LMS

* ref: #1
* `url_check: https://canvas.instructure.com/register — HTTP 503, failing since 2026-08-15 (5 days, 3 checks)`

### Drop demo_url from ManageMeals

* ref: #1
* `url_check: https://demo.managemeals.com/ — HTTP 502, failing since 2026-08-15 (5 days, 3 checks)`
