### PR TITLE
fix related_software key in immich-kiosk

### DIFF
--- a/software/immich-kiosk.yml
+++ b/software/immich-kiosk.yml
@@ -9,7 +9,7 @@ platforms:
   - Go
 tags:
   - Photo Galleries
-related_software: https://github.com/immich-app/immich
+related_software_url: https://github.com/immich-app/immich
 stargazers_count: 1630
 updated_at: '2026-08-14'
 archived: false


### PR DESCRIPTION
- related_software_url instead of related_software
