### PR TITLE
Add OLVM Portal Community (Remote Access)

### DIFF
--- a/software/olvm-portal-community.yml
+++ b/software/olvm-portal-community.yml
@@ -1,0 +1,15 @@
+name: OLVM Portal Community
+website_url: https://olvm-portal.sixmanager.io
+description: Multitenant web portal for Oracle Linux Virtualization Manager (OLVM) and oVirt with 1-click VM operations, embedded VNC console, OVA/QCOW2 imports and scheduled backups.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Remote Access
+source_code_url: https://github.com/npalmae/olvm-portal-community
+demo_url: https://olvm-portal.sixmanager.io
+stargazers_count: 1
+updated_at: '2026-08-21'
+archived: false


### PR DESCRIPTION
Adds OLVM Portal Community — a multitenant web portal for Oracle Linux Virtualization Manager (OLVM) and oVirt.

- Web UI (Next.js), deployed via Docker
- 1-click VM operations with embedded VNC console in the browser
- OVA/QCOW2 imports with automated conversion
- Scheduled S3/Wasabi backups with SHA-256 verification
- Role-based access (operator/user/admin/superadmin) with tenant isolation via OLVM tags
- MIT license, live demo available

Categorized under Remote Access alongside Guacamole/MeshCentral (web interface for remote management of virtualized systems).