### PR TITLE
Add Aruvi

### DIFF
--- a/software/aruvi.yml
+++ b/software/aruvi.yml
@@ -1,0 +1,14 @@
+name: Aruvi
+website_url: https://github.com/tirforge/Aruvi
+description: Self-hosted media platform that streams files from your own private Telegram channel to Web, Android, Android TV and Desktop clients, with multi-bot parallel fetching and two-tier caching.
+licenses:
+  - MIT
+platforms:
+  - python
+  - docker
+  - deb
+tags:
+  - Media Streaming - Multimedia Streaming
+source_code_url: https://github.com/tirforge/Aruvi
+demo_url: https://movie.aaruvi.space
+depends_3rdparty: true


### PR DESCRIPTION
Adds [Aruvi](https://github.com/tirforge/Aruvi) — a self-hosted media platform that streams files from the user's own private Telegram channel to Web, Android, Android TV and Desktop clients.

- Multi-bot parallel fetching with RAM/disk two-tier caching, built-in grabber, subtitle search
- MIT licensed, active development, Docker + deb deploys
- Depends on Telegram (third-party) — flagged via `depends_3rdparty: true`
- Entry follows `software/aruvi.yml` schema per CONTRIBUTING.md