### PR TITLE
Add Kibbutznik

### DIFF
--- a/software/kibbutznik.yml
+++ b/software/kibbutznik.yml
@@ -1,0 +1,11 @@
+name: Kibbutznik
+website_url: https://kibbutznik.org/
+source_code_url: https://github.com/Kibbutznik/kibbutznik
+description: Governance engine for self-governing groups. Members propose rules, support gathers in the open, and a recurring pulse turns enough support into a decision. Supports nested sub-communities and has no admin tier.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Communication - Social Networks and Forums
+demo_url: https://kibbutznik.org/kbz/viewer/


### PR DESCRIPTION
Adds [Kibbutznik](https://kibbutznik.org/) — a self-hosted governance engine for groups that make decisions together.

Members propose changes to a shared rulebook (plain-language statements plus tunable variables), support gathers in the open, and a recurring "pulse" turns enough support into a decision. It also supports nested sub-communities, and has no admin tier — every rule and threshold, including the support threshold itself, is proposable.

Runs on Python 3.12 / FastAPI / PostgreSQL on a single small VPS. No third-party service is required (the optional LLM features can run fully locally via Ollama).

Live demo: https://kibbutznik.org/kbz/viewer/

- [x] Submit one item per issue/PR.
- [x] Searched the repository for relevant issues and PRs, including closed ones (no existing entry or submission).
- [x] Not already listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, or dbdb.io.
- [x] Actively maintained.
- [x] First released more than 4 months ago (repository created 2026-04-21).
- [x] Has working installation instructions ([Quick start](https://github.com/Kibbutznik/kibbutznik#quick-start)).