### PR TITLE
add keel

### DIFF
--- a/software/keel.yml
+++ b/software/keel.yml
@@ -15,4 +15,4 @@ current_release:
   tag: v0.11.0
   published_at: '2026-08-21'
 commit_history:
-  2026-08: 0
+  2026-08: 295

--- a/software/keel.yml
+++ b/software/keel.yml
@@ -1,0 +1,18 @@
+name: keel
+website_url: https://keeltrading.com/
+description: Auditable Shariah-compliance engine for spot cryptocurrency trading.
+licenses:
+  - Apache-2.0
+platforms:
+  - Python
+tags:
+  - Money, Budgeting & Management
+source_code_url: https://github.com/CodeGateSoftware/keel
+stargazers_count: 3
+updated_at: '2026-08-22'
+archived: false
+current_release:
+  tag: v0.11.0
+  published_at: '2026-08-21'
+commit_history:
+  2026-08: 0


### PR DESCRIPTION
Adds **keel** — an auditable Shariah-compliance engine for spot cryptocurrency trading (Apache-2.0, Python, self-hosted by design) — under *Money, Budgeting & Management*.

- Website: https://keeltrading.com/ · Source: https://github.com/CodeGateSoftware/keel
- What it does: attested fail-closed asset screening, AAOIFI §65.4 qabd (constructive possession) enforcement, and purification accounting, with a reference auto-trading agent for Coinbase. No cloud service, no accounts, keys never leave the operator's machine.
- Current release v0.11.0 (2026-08-21); the public repo is young — the project launched this month, so the commit history shows one month. If that fails the activity/maturity expectations, happy to resubmit later — just say the word.

**Disclosure, in the project's own spirit:** I am the maintainer of keel.