### PR TITLE
Add Beaver

### DIFF
--- a/software/beaver.yml
+++ b/software/beaver.yml
@@ -1,0 +1,10 @@
+name: Beaver
+website_url: https://github.com/zaengit/beaver
+description: Astro CMS integration with an admin panel, SQLite-backed content management, media handling, menus, site settings, and configurable content types.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Content Management Systems (CMS)
+source_code_url: https://github.com/zaengit/beaver


### PR DESCRIPTION
## Summary

- Add Beaver to the Content Management Systems (CMS) category.
- Beaver is an Astro SSR CMS integration with an admin panel, SQLite-backed content management, media handling, menus, site settings, and configurable content types.

## Installation

```bash
npm create @zbeaver/beaver
```

## Checklist

- [x] This is the only software added in this PR.
- [x] The YAML follows the addition template.
- [x] The project has working installation instructions.
- [ ] The project was first released more than four months ago.

The first tagged release (`v0.1.7`) was published on 2026-08-20, so Beaver does not yet meet the four-month maturity requirement. This PR is submitted now at the author's request; please close it if the rule must be enforced. Beaver can be resubmitted after approximately 2026-12-20.

Refs #2959
