### PR TITLE
Add gh-stats

### DIFF
--- a/software/gh-stats.yml
+++ b/software/gh-stats.yml
@@ -1,0 +1,12 @@
+name: gh-stats
+website_url: https://gh-stats.com
+description: Renders GitHub profile statistics as a single SVG card for embedding in a README, with per-widget endpoints, themes, and light/dark auto-switching. Self-hosting uses your own GitHub API rate limit.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Software Development - IDE & Tools
+source_code_url: https://github.com/ShayManor/github-readme-stats
+demo_url: https://gh-stats.com


### PR DESCRIPTION
Adds [gh-stats](https://github.com/ShayManor/github-readme-stats), a self-hosted renderer for GitHub profile statistics cards.

It generates an SVG summarising a GitHub profile (score/grade, contribution timeline, top collaborators, language breakdown, commit streaks) for embedding in a README, plus per-widget endpoints and themes.

Why self-host it: the widely used public instances of this kind of card are shared and heavily rate limited, so cards intermittently fail to render. Running your own means the renderer uses your own GitHub API rate limit.

- Licence: MIT
- First release: v0.0, 2026-04-17 (over 4 months old, per the guidelines)
- Latest release: v0.1.0, which is the release that added the self-hosting path
- Runs with `docker compose up -d --build`; only `GITHUB_PAT` and `FETCHER_INTERNAL_TOKEN` are required
- Demo: https://gh-stats.com

Verified from a clean clone before submitting: all three images build, all five containers start, the web UI and `/api/health` respond, and the caching proxy answers with `upstream_ok`.

On the tag: I used `Software Development - IDE & Tools` as the closest existing fit for developer tooling, but it is not an IDE, so please re-tag it (`Analytics` or `Miscellaneous`) if you would rather it sat elsewhere.

Disclosure: I am the author.