### PR TITLE
Add Nibi

### DIFF
--- a/software/nibi.yml
+++ b/software/nibi.yml
@@ -1,0 +1,10 @@
+name: Nibi
+website_url: https://github.com/Cavaggion/nibi
+description: Self-hosted kanban for humans and AI agents. One JSON file is the source of truth, zero dependencies, stable JSON CLI and HTTP API for agents.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Task Management & To-do Lists
+source_code_url: https://github.com/Cavaggion/nibi


### PR DESCRIPTION
## What is this?

[Nibi](https://github.com/Cavaggion/nibi) is a self-hosted kanban for humans and AI agents:
- one JSON file as the source of truth (no database, versionable with git)
- zero dependencies: Python 3 stdlib server + vanilla web app
- stable `--json` CLI and a dead-simple HTTP API, so AI agents (Hermes, Claude Code, Codex...) can read and update the board
- dark/light themes, deadline badges, dependent tasks as nested cards, macOS app wrapper

MIT licensed, actively maintained.