### PR TITLE
Add Orch8

### DIFF
--- a/software/orch8.yml
+++ b/software/orch8.yml
@@ -1,0 +1,11 @@
+name: Orch8
+website_url: https://orch8.io/
+description: Durable workflow engine with persistent execution, retries, checkpoints, rate limits, human approvals, and crash recovery, written in Rust.
+licenses:
+  - BUSL-1.1
+platforms:
+  - Docker
+  - Rust
+tags:
+  - Automation
+source_code_url: https://github.com/orch8-io/engine


### PR DESCRIPTION
Adds [Orch8](https://orch8.io/) to the Automation category.

Orch8 is licensed under BUSL-1.1, which this repository classifies as non-Free, so it should render on the Non-Free page rather than the FOSS list. The source is available at https://github.com/orch8-io/engine.

- [x] Submit one item per pull request.
- [x] Searched relevant issues and PRs, including closed ones.
- [x] Confirmed Orch8 is not listed in awesome-selfhosted, awesome-sysadmin, or staticgen.
- [x] The file follows the addition template and uses kebab-case.
- [x] Comments and unused optional fields were removed.
- [x] Platforms match the Docker deployment and Rust implementation.
- [x] The project is actively maintained.
- [x] The first tagged release was published on 2026-04-22, more than four months ago.
- [x] Working Docker installation instructions are available at https://github.com/orch8-io/engine#docker
- [x] I understand merge timing depends on maintainer review.

Validation: YAML parses successfully and git diff --check passes.