### PR TITLE
Add OTP Board

### DIFF
--- a/software/otp-board.yml
+++ b/software/otp-board.yml
@@ -1,0 +1,13 @@
+name: "OTP Board"
+website_url: "https://github.com/TOBYCAI/otp-board"
+source_code_url: "https://github.com/TOBYCAI/otp-board"
+description: "Self-hosted OTP/verification-code dashboard. Android client forwards SMS and system notifications over HTTPS to a zero-dependency Node.js server for centralized viewing, de-duplication and CSV export."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Automation
+  - Communication - Custom Communication Systems
+depends_3rdparty: false


### PR DESCRIPTION
Add OTP Board - self-hosted OTP/verification-code dashboard (Android client forwards SMS & system notifications over HTTPS to a zero-dependency Node.js server).

MIT licensed. Nodejs + Docker. Tags: Automation, Communication - Custom Communication Systems.