### PR TITLE
add Rustrak

### DIFF
--- a/software/rustrak.yml
+++ b/software/rustrak.yml
@@ -1,0 +1,11 @@
+name: Rustrak
+website_url: https://rustrak.github.io/rustrak/
+source_code_url: https://github.com/rustrak/rustrak
+description: Error tracking server compatible with Sentry SDKs, using 32 MB of memory at idle with SQLite storage.
+licenses:
+  - GPL-3.0
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Ticketing


### PR DESCRIPTION
Adding Rustrak, a self-hosted error tracking server that accepts events from any Sentry SDK by changing the DSN. Tagged `Ticketing`, which the tag description covers.

Supersedes #2817, which I've closed.

First release 2026-01-22. Disclosure: I'm the author.

- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.
