### PR TITLE
move PdfDing to Codeberg

### DIFF
--- a/software/pdfding.yml
+++ b/software/pdfding.yml
@@ -1,6 +1,6 @@
 name: PdfDing
 website_url: https://www.pdfding.com
-source_code_url: https://github.com/mrmn2/PdfDing
+source_code_url: https://codeberg.org/mrmn/PdfDing
 demo_url: https://demo.pdfding.com
 description: PDF manager, viewer and editor offering a seamless user experience on multiple devices. It's designed to be minimal, fast, and easy to set up using Docker.
 licenses:
@@ -10,22 +10,3 @@ platforms:
   - K8S
 tags:
   - Document Management
-stargazers_count: 1854
-updated_at: '2026-08-25'
-archived: true
-current_release:
-  tag: v1.13.0
-  published_at: '2026-08-11'
-commit_history:
-  2025-09: 7
-  2025-10: 16
-  2025-11: 57
-  2025-12: 20
-  2026-01: 19
-  2026-02: 21
-  2026-03: 43
-  2026-04: 7
-  2026-05: 0
-  2026-06: 30
-  2026-07: 17
-  2026-08: 33


### PR DESCRIPTION
- ref: #1
- `ERROR:awesome_lint.py: PdfDing: the project is archived`
- https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/33055295660/job/98538015307
- https://github.com/mrmn2/PdfDing/commit/2f7aae62fa215dbe7f62809c44119c8939f853cf