### PR TITLE
add Lucidos

### DIFF
--- a/software/lucidos.yml
+++ b/software/lucidos.yml
@@ -1,0 +1,14 @@
+name: Lucidos
+website_url: https://lucidos.dev
+source_code_url: https://github.com/lucidos-dev/lucidos
+description: Local AI operating system where you describe an app or an automation in chat and it runs seconds later, against your own files, data and API credentials.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Nodejs
+tags:
+  - Automation
+  - Generative Artificial Intelligence (GenAI)
+  - Personal Dashboards
+  - Self-hosting Solutions


### PR DESCRIPTION
Adds Lucidos, a self-hosted local AI operating system. New file `software/lucidos.yml`.

Lucidos runs entirely on the user's own machine. You describe an app or an automation in chat and it builds and runs it against your own files, data and API credentials. No Lucidos-operated service exists, and local models are supported, so nothing has to leave the machine.

- Homepage: https://lucidos.dev
- Source: https://github.com/lucidos-dev/lucidos
- License: MIT
- Install: `curl -fsSL https://lucidos.dev/install.sh | sh`, or a signed macOS DMG from Releases. No Docker required.
- Releases: 60 releases, first published 2026-04-27 (https://github.com/lucidos-dev/lucidos/releases)

Note on the commit history: the public repo is a squashed publish, so the commit list looks younger than the project is. The releases page is the accurate record of age and activity.

- [x] Submit one item per issue. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software you are adding is not already listed at any of awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, dbdb.io.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
