### PR TITLE
Add VoltPhish

### DIFF
--- a/software/voltphish.yml
+++ b/software/voltphish.yml
@@ -1,0 +1,11 @@
+name: VoltPhish
+website_url: https://hub.docker.com/r/baymaxarmed/voltphish
+source_code_url: https://github.com/Baymax-armed/Voltphish
+description: Platform for running internal phishing simulations and security-awareness training, with multi-vector lures (email, QR, calendar), a report-phish button, a training module system with auto-enrollment, and per-user human-risk analytics.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+  - Python
+tags:
+  - Miscellaneous


### PR DESCRIPTION
Adds **VoltPhish** — a free, open-source (AGPL-3.0), self-hosted platform for running internal phishing simulations and security-awareness training.

It runs the full awareness loop from a single Docker container: multi-vector lures (email, QR, calendar), a report-phish button (Outlook/Gmail), a built-in training module system with adaptive auto-enrollment, and per-user/department human-risk analytics — with all data staying on the operator's own infrastructure. Authorized/defensive use only.

- Source: https://github.com/Baymax-armed/Voltphish
- License: AGPL-3.0
- Platforms: Docker, Python
- Tagged `Miscellaneous` (there isn't a dedicated security-awareness/phishing category yet).

Passes local YAML validation. Happy to adjust the tag/description to fit the project's conventions.