### PR TITLE
add Celmis

### DIFF
--- a/software/celmis.yml
+++ b/software/celmis.yml
@@ -1,0 +1,12 @@
+name: Celmis
+website_url: https://celmis-labs.github.io
+description: Code intelligence over a symbol graph of your repositories. Ask questions that cross repository boundaries and get file and line citations, review pull requests, audit dependencies into a CycloneDX SBOM, and serve the index over MCP.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Python
+  - Nodejs
+  - Docker
+tags:
+  - Software Development - IDE & Tools
+source_code_url: https://github.com/Celmis-labs/Celmis


### PR DESCRIPTION
Adds `software/celmis.yml`.

Celmis is self-hosted code intelligence. It indexes a set of repositories once into a symbol graph; asking questions, reviewing pull requests, auditing dependencies and serving an MCP endpoint are then different ways of reading that one index.

Relevant to this list specifically:

- Runs on one machine under `docker compose`. Postgres and Qdrant are bundled — no external cluster to provision.
- **No telemetry and no licence check.** The only outbound calls are the ones the operator configures for their own model provider (Gemini, Anthropic, OpenAI, OpenRouter, Groq or Mistral — bring your own key).
- AGPL-3.0 for the whole thing, not open core.
- A first install on a clean server took 197 seconds from `git clone` to six healthy services; roughly 1.1 GB of RAM at peak during indexing, 565 MB at rest.

Tagged `Software Development - IDE & Tools` — `Software Development` itself carries a `redirect`, so it takes no software items.

Documentation, including a first install and the architecture: https://celmis-labs.github.io/docs/

Disclosure: I maintain the project, and it is new — first public release this week. If the list would rather see more history before including it, say so and I will resubmit later rather than sit in the queue.
