### PR TITLE
Update Cannery source repository to GitLab

### DIFF
--- a/software/cannery.yml
+++ b/software/cannery.yml
@@ -1,6 +1,6 @@
 name: "Cannery"
 website_url: "https://cannery.app"
-source_code_url: "https://codeberg.org/shibao/cannery"
+source_code_url: "https://gitlab.com/shibaobun/cannery"
 description: "Firearm and ammunition tracker app."
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
Cannery has moved from Codeberg to GitLab.

- `source_code_url`: https://codeberg.org/shibao/cannery → https://gitlab.com/shibaobun/cannery
- Website remains https://cannery.app