### PR TITLE
Update memEx repository to GitLab

### DIFF
--- a/software/memex.yml
+++ b/software/memex.yml
@@ -1,6 +1,6 @@
 name: "memEx"
-website_url: "https://codeberg.org/shibao/memEx"
-source_code_url: "https://codeberg.org/shibao/memEx"
+website_url: "https://gitlab.com/shibaobun/memex"
+source_code_url: "https://gitlab.com/shibaobun/memex"
 description: "Structured personal knowledge base, inspired by zettlekasten and org-mode."
 licenses:
   - AGPL-3.0


### PR DESCRIPTION
memEx has moved from Codeberg to GitLab.

- `website_url` and `source_code_url`: https://codeberg.org/shibao/memEx → https://gitlab.com/shibaobun/memex