### PR TITLE
add Tianji software

### DIFF
--- a/software/tianji.yml
+++ b/software/tianji.yml
@@ -1,0 +1,10 @@
+name: Tianji
+website_url: https://github.com/zhujunhuo-ops/tianji
+source_code_url: https://github.com/zhujunhuo-ops/tianji
+description: Local-first AI butler with voice & vision. Offline wake word and speech recognition, semantic memory with vector search, SKILL.md document-driven skills, zero-key web search, Home Assistant control, and a multiplayer world with relay.
+licenses:
+  - MIT
+platforms:
+  - Python
+tags:
+  - Generative Artificial Intelligence (GenAI)


### PR DESCRIPTION
## What does this PR do?

Adds [Tianji (修真录 · 天机)](https://github.com/zhujunhuo-ops/tianji) to the GenAI category.

- Local-first AI butler with voice & vision
- Offline wake word + faster-whisper speech recognition + free edge-tts
- Semantic memory (bge-small-zh vector search, auto-degrade)
- SKILL.md document-driven skill system
- Zero-key web search
- Home Assistant control
- Multiplayer world with zero-dependency relay server
- Core server is pure Python stdlib (no third-party deps)
- MIT licensed, actively developed (daily releases)