### PR TITLE
Add URL to PDF Microservice (maintained fork of alvarcarto/url-to-pdf-api)

### DIFF
--- a/software/url-to-pdf-api.yml
+++ b/software/url-to-pdf-api.yml
@@ -1,0 +1,10 @@
+name: URL to PDF Microservice
+website_url: https://github.com/Ant19801108/url-to-pdf-api
+source_code_url: https://github.com/Ant19801108/url-to-pdf-api
+description: "Web page PDF and screenshot rendering microservice. Converts any URL or HTML content to PDF, PNG or JPEG using headless Chrome."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+tags:
+  - Miscellaneous


### PR DESCRIPTION
## Software

**URL to PDF Microservice** — Web page PDF and screenshot rendering microservice (headless Chrome / Puppeteer). Converts any URL or HTML content to PDF, PNG or JPEG.

- Website/source: https://github.com/Ant19801108/url-to-pdf-api
- License: MIT
- Platform: Node.js
- This is an actively maintained fork of `alvarcarto/url-to-pdf-api` (7.1k stars, dormant since 2024). The fork updates dependencies (Puppeteer 24, Express 4.21), fixes the code for modern Node, and adds a screenshot endpoint.

Checklist:
- [x] One item per PR
- [x] Not already listed
- [x] Actively maintained
- [x] First released more than 4 months ago (original project, 2016)
- [x] Working installation instructions