### PR TITLE
Add Scraperr (maintained fork of jaypyles/Scraperr)

### DIFF
--- a/software/scraperr.yml
+++ b/software/scraperr.yml
@@ -1,0 +1,11 @@
+name: Scraperr
+website_url: https://github.com/Ant19801108/Scraperr
+source_code_url: https://github.com/Ant19801108/Scraperr
+description: "Self-hosted web scraper with a web UI. Select elements on a page (no-code XPath) and export the scraped data."
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Nodejs
+tags:
+  - Miscellaneous


### PR DESCRIPTION
## Software

**Scraperr** — Self-hosted web scraper with a web UI (no-code XPath scraping).

- Source: https://github.com/Ant19801108/Scraperr
- License: MIT
- Platforms: Python (FastAPI) + Node.js (Next.js)
- This is an actively maintained fork of `jaypyles/Scraperr` (4.9k stars, archived).

Checklist:
- [x] One item per PR
- [x] Not already listed
- [x] Actively maintained
- [x] First released more than 4 months ago (original project)
- [x] Working installation instructions