### PR TITLE
add ImmortalWrt Gateway Docker

### DIFF
--- a/software/immortalwrt-docker.yml
+++ b/software/immortalwrt-docker.yml
@@ -1,0 +1,11 @@
+name: ImmortalWrt Gateway Docker
+website_url: https://hub.docker.com/r/hasanjws/immortalwrt-gateway
+description: Multi-architecture ImmortalWrt sidecar and bypass gateway container with pre-bundled OpenClash, Mihomo core, and WireGuard.
+licenses:
+  - GPL-3.0
+platforms:
+  - Docker
+tags:
+  - Network Utilities
+  - Proxy
+source_code_url: https://github.com/SwiftExplorer567/immortalwrt-docker


### PR DESCRIPTION
### Summary
Add ImmortalWrt Gateway Docker under \Network Utilities\ and \Proxy\.

- **Name:** ImmortalWrt Gateway Docker
- **Website:** https://hub.docker.com/r/hasanjws/immortalwrt-gateway
- **Source Code:** https://github.com/SwiftExplorer567/immortalwrt-docker
- **License:** GPL-3.0
- **Platforms:** Docker
- **Tags:** Network Utilities, Proxy
- **Description:** Multi-architecture ImmortalWrt sidecar and bypass gateway container with pre-bundled OpenClash, Mihomo core, and WireGuard.

### Checklist
- [x] Item name is in sentence case
- [x] URL is valid and accessible
- [x] Description is under 250 characters
- [x] License is in licenses.yml
- [x] Platform is in platforms/
- [x] Tags are in tags/