### PR TITLE
add Waxum

### DIFF
--- a/software/waxum.yml
+++ b/software/waxum.yml
@@ -1,0 +1,12 @@
+name: Waxum
+website_url: https://waxum.imtaqin.id
+source_code_url: https://github.com/imtaqin/waxum
+description: WhatsApp gateway exposing messaging, groups, media and voice calls over a REST API, with webhooks and multi-session support. Distributed as a single static Rust binary.
+licenses:
+  - MIT
+platforms:
+  - Rust
+  - Docker
+tags:
+  - Communication - Custom Communication Systems
+depends_3rdparty: true


### PR DESCRIPTION
Adds **Waxum**, a WhatsApp gateway written in Rust. You run one binary, it holds the WhatsApp sessions and exposes them over a REST API plus webhooks, so anything on your network can send and receive messages without a browser automation stack.

Filed under `Communication - Custom Communication Systems`.

A note on `depends_3rdparty: true` — set deliberately. The software itself is entirely self-hosted, but it connects to WhatsApp, which is outside the user's control.

Thanks for taking the time to suggest an addition to awesome-selfhosted!

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly. — no `demo_url` is set; there is no public interactive demo, since a live WhatsApp account would be required.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software. — `Rust` and `Docker`. Prebuilt binaries and an official image are both published.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago. — first release `v0.2.0` on 2026-03-26; 50 tagged releases to date, latest `v0.12.4` on 2026-08-28.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.

### Supporting detail

- **Licence:** MIT — [LICENSE](https://github.com/imtaqin/waxum/blob/dev/LICENSE). Heads-up for reviewers: the file currently sits on the `dev` branch and has not yet been promoted to `main`, so GitHub's sidebar licence detection does not show it yet. The link above is the actual text. Happy to hold this PR until it lands on the default branch if you would prefer that.
- **Install instructions:** [README — Install](https://github.com/imtaqin/waxum#install) covers a shell installer for Linux/macOS, PowerShell for Windows, and Docker Compose.
- **Runtime:** a single static Rust binary. No Node, Python, or headless Chromium runtime required.
- **Interface:** built-in web console for fleet overview and per-session testing, plus a Swagger UI at `/swagger-ui`. It is not API-only.
- **Scope:** 180+ REST endpoints across 29 feature modules — messaging, groups, contacts, presence, media, webhooks, voice calls. Multi-session, with Postgres, MySQL, or SQLite as the store.
- **Ops:** `/livez` and `/readyz` probes and a Prometheus `/metrics` endpoint.
