### PR TITLE
Add Jous

### DIFF
--- a/software/jous.yml
+++ b/software/jous.yml
@@ -1,0 +1,13 @@
+name: Jous
+website_url: https://jous.app
+source_code_url: https://github.com/helia94/jous
+description: Social question-and-answer network built around random conversation cards; draw random questions, answer publicly or anonymously, add your own, and form groups.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Nodejs
+  - Docker
+tags:
+  - Communication - Social Networks and Forums
+demo_url: https://jous.app/random


### PR DESCRIPTION
Adds **Jous** — an MIT-licensed, self-hostable social Q&A app built around random conversation cards.

- Website: https://jous.app (also serves as a live demo, no signup needed: https://jous.app/random)
- Source: https://github.com/helia94/jous (Flask + PostgreSQL backend, React frontend, docker-compose for local setup)
- Active since 2021, ~1,700 questions in the public instance, UI/content in EN/DE/ES/FA.
- Optional integrations (OpenAI for auto-translation) degrade gracefully when unconfigured.