### PR TITLE
add Quven

### DIFF
--- a/software/quven.yml
+++ b/software/quven.yml
@@ -1,0 +1,13 @@
+name: Quven
+website_url: https://quven.tv/
+description: Media server for movies, TV shows and documentaries, with native desktop, mobile and TV clients. Direct play, hardware transcoding, HDR tone-mapping and subtitle generation from the audio track.
+licenses:
+  - ⊘ Proprietary
+platforms:
+  - C#
+  - Docker
+tags:
+  - Media Streaming - Video Streaming
+depends_3rdparty: true
+source_code_url: https://quven.tv/
+related_software_url: https://quven.tv/apps


### PR DESCRIPTION
Adds Quven, a self-hosted media server for movies, TV shows and documentaries. It is proprietary, so it belongs in the non-free list alongside Plex and Emby.

`depends_3rdparty` is set to `true`: a Quven account is required at first sign-in, after which the server keeps working offline for seven days. Media, library and playback stay on the operator's hardware, but the sign-in itself is not self-contained and readers of this list should know that up front.

Installation is documented for Docker, Linux, Windows and macOS at https://quven.tv/guides. First public release 1.0.0 on 2026-01-15, releases roughly weekly since, currently 1.1.16.

- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software you are adding is not already listed at any of awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, dbdb.io.
- [x] The file you are adding is formatted as described in addition.md.
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses kebab-case file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.
