### PR TITLE
update meme-search URL

### DIFF
--- a/software/meme-search.yml
+++ b/software/meme-search.yml
@@ -7,7 +7,7 @@ platforms:
   - Docker
 tags:
   - Search Engines
-source_code_url: https://github.com/neonwatty/meme-search
+source_code_url: https://github.com/meme-search/meme-search
 stargazers_count: 719
 updated_at: '2026-08-31'
 archived: false


### PR DESCRIPTION
- ERROR:software_metadata.py: repository not found in search results: https://github.com/neonwatty/meme-search
