### PR TITLE
Add masque-vpn

### DIFF
--- a/software/masque-vpn.yml
+++ b/software/masque-vpn.yml
@@ -1,0 +1,10 @@
+name: masque-vpn
+website_url: https://github.com/Next1971/masque-vpn
+source_code_url: https://github.com/Next1971/masque-vpn
+description: Self-hosted VPN server using MASQUE CONNECT-IP over HTTP/3 with mTLS authentication and Android, Android TV, and Windows clients.
+licenses:
+  - MIT
+platforms:
+  - Go
+tags:
+  - VPN

--- a/software/masque-vpn.yml
+++ b/software/masque-vpn.yml
@@ -7,4 +7,4 @@ licenses:
 platforms:
   - Go
 tags:
-  - VPN
+  - Proxy


### PR DESCRIPTION
## Add masque-vpn

Adds `masque-vpn` to the Proxy category (the VPN tag is redirect-only).

- Project URL: https://github.com/Next1971/masque-vpn
- License: MIT
- Server: self-hosted MASQUE CONNECT-IP proxy over HTTP/3 with mTLS authentication
- Clients: Android, Android TV, and Windows

The project has a current stable release (v1.5.0) and installation/documentation in its repository.

- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant issues or PRs, including closed ones.
- [x] Any software you are adding is not already listed at any of awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me, dbdb.io.
- [x] The file you are adding is formatted as described in addition.md.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses kebab-case file naming.
- [x] Values for platform should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.