### PR TITLE
Update LibreDB Studio description

### DIFF
--- a/software/libredb-studio.yml
+++ b/software/libredb-studio.yml
@@ -1,7 +1,7 @@
 name: LibreDB Studio
 website_url: https://libredb.org
 source_code_url: https://github.com/libredb/libredb-studio
-description: Browser-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis, with an optional AI assistant that writes SQL from natural language (alternative to DataGrip, DBeaver).
+description: Browser-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Redis, ClickHouse, DuckDB and more, with SSO, audit trail, ER diagrams and optional AI assistance on your own model key (alternative to DataGrip, DBeaver, CloudBeaver).
 licenses:
   - MIT
 platforms:


### PR DESCRIPTION
Updates the description of an existing entry, `software/libredb-studio.yml`. No new software.

The current text names seven engines and "an optional AI assistant that writes SQL from natural language". Since it was written, the project added ClickHouse, DuckDB, Couchbase, Cassandra, Elasticsearch, OpenSearch, Trino, Druid and libSQL, and the AI feature is optional assistance on the user's own model key rather than a natural-language-to-SQL generator, so the old sentence overstated it. The new text also mentions SSO, audit trail and ER diagrams, and adds CloudBeaver as the closest browser-based alternative.

Written per CONTRIBUTING: no "open-source/free/self-hosted" wording, short form, alternatives at the end. I maintain the project.