### PR TITLE
Add SendDock

### DIFF
--- a/software/senddock.yml
+++ b/software/senddock.yml
@@ -1,0 +1,11 @@
+name: SendDock
+website_url: https://senddock.dev
+source_code_url: https://github.com/Arkhe-Systems/senddock
+description: Email marketing and transactional sending where each project is its own sending identity (own SMTP, domain, subscribers and analytics).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Docker
+tags:
+  - Communication - Email - Mailing Lists and Newsletters


### PR DESCRIPTION
Add SendDock, an email marketing and transactional sending platform where each project is its own sending identity (own SMTP, domain, subscribers and analytics).

- [x] Submit one item per pull request.
- [x] Searched issues and PRs; not already listed.
- [x] Not listed in awesome-sysadmin / staticgen / dbdb.io.
- [x] File formatted as described in addition.md.
- [x] Demo omitted (no login-free interactive demo).
- [x] Comments and unused optional fields removed.
- [x] kebab-case filename (`senddock.yml`).
- [x] `platforms` match install/run: Go + Docker.
- [x] Actively maintained.
- [x] First release more than 4 months ago (v0.5.2, 2026-04-30).
- [x] Working installation instructions (one-line installer, Docker Compose).
