### PR TITLE
add ClickTrail

### DIFF
--- a/software/clicktrail.yml
+++ b/software/clicktrail.yml
@@ -1,0 +1,10 @@
+name: ClickTrail
+website_url: https://wordpress.org/plugins/click-trail-handler/
+source_code_url: https://github.com/vizuh/click-trail-handler
+description: First-party campaign attribution for WordPress forms and WooCommerce, preserving UTM parameters and ad click IDs with consent controls.
+licenses:
+  - GPL-2.0
+platforms:
+  - PHP
+tags:
+  - Analytics


### PR DESCRIPTION
Thanks for taking the time to suggest an addition to awesome-selfhosted!

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):

- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.

ClickTrail was first released on WordPress.org on December 11, 2025. Its public listing provides installation instructions and currently serves version 1.9.1, released August 27, 2026.

`make awesome_lint` passes locally.

Disclosure: I maintain ClickTrail.
