### PR TITLE
Add ICTFax

### DIFF
--- a/software/ictfax.yml
+++ b/software/ictfax.yml
@@ -1,0 +1,12 @@
+name: ICTFax
+website_url: https://www.ictfax.org/
+description: Multi-user fax server for sending and receiving faxes over T.38 and G.711 SIP trunks, with email-to-fax, fax-to-email, web fax, DIDs, extensions and a REST API.
+licenses:
+  - GPL-3.0
+platforms:
+  - PHP
+  - Docker
+tags:
+  - Communication - SIP
+source_code_url: https://github.com/ictinnovations/ictfax
+demo_url: https://demo.ictfax.com/


### PR DESCRIPTION
Adds ICTFax under Communication - SIP.

ICTFax is a self-hosted fax server: it sends and receives faxes over T.38 and G.711 SIP trunks, does email-to-fax and fax-to-email, and has a web interface, DIDs, extensions, multi-user support and a REST API. GPL-3.0. The source has been on GitHub since 2013, tagged releases since 2017, and the latest commits are from last week. A Docker image is published on Docker Hub, and demo.ictfax.com is a public demo instance.

Disclosure: I maintain the project (ICT Innovations). Happy to adjust the description or tags if the fit is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVSvQVhZL3VYd8MxhTm7Yj
