### PR TITLE
add Hoardodile

### DIFF
--- a/software/hoardodile.yml
+++ b/software/hoardodile.yml
@@ -1,0 +1,12 @@
+name: Hoardodile
+website_url: https://www.hoardodile.com
+description: Versioned archive library for the things you keep: images, documents, PDFs, video, audio, web pages and more, previewed in place, rendered by content plugins, and kept on your own storage.
+licenses:
+  - GPL-3.0
+platforms:
+  - Docker
+  - Nodejs
+tags:
+  - Archiving and Digital Preservation (DP)
+source_code_url: https://github.com/hoardodile/hoardodile
+related_software_url: https://github.com/hoardodile/marketplace


### PR DESCRIPTION
Self-hosted versioned archive library (GPL-3.0) for images, documents, PDFs, video, audio, web pages and more, rendered by content plugins.

- Website: https://www.hoardodile.com (verified reachable)
- Source: https://github.com/hoardodile/hoardodile
- Related software: https://github.com/hoardodile/marketplace (plugin marketplace)
- Platforms: Docker, Nodejs
- Tag: Archiving and Digital Preservation (DP)

Related entries: ArchiveBox, LinkWarden, Readeck, Karakeep.