### PR TITLE
add lamco-rdp-server

### DIFF
--- a/software/lamco-rdp-server.yml
+++ b/software/lamco-rdp-server.yml
@@ -1,7 +1,7 @@
 name: lamco-rdp-server
 website_url: https://www.lamco.ai/products/lamco-rdp-server/
 source_code_url: https://github.com/lamco-admin/lamco-rdp-server
-description: Wayland-native RDP server for remote desktop access to GNOME, KDE, Sway, and Hyprland (alternative to xrdp, RustDesk).
+description: Wayland-native RDP server for remote desktop access across Wayland Linux desktops (alternative to xrdp, RustDesk).
 licenses:
   - BUSL-1.1
 platforms:

--- a/software/lamco-rdp-server.yml
+++ b/software/lamco-rdp-server.yml
@@ -1,0 +1,10 @@
+name: lamco-rdp-server
+website_url: https://www.lamco.ai/products/lamco-rdp-server/
+source_code_url: https://github.com/lamco-admin/lamco-rdp-server
+description: Wayland-native RDP server for remote desktop access to GNOME, KDE, Sway, and Hyprland (alternative to xrdp, RustDesk).
+licenses:
+  - BUSL-1.1
+platforms:
+  - Rust
+tags:
+  - Remote Access


### PR DESCRIPTION
Adds lamco-rdp-server to Remote Access.

Native Wayland RDP server built on IronRDP. Works across Wayland Linux desktops without X11.