### PR TITLE
remove demo of openreader

### DIFF
--- a/software/openreader.yml
+++ b/software/openreader.yml
@@ -1,5 +1,5 @@
 name: OpenReader
-website_url: https://openreader.richardr.dev/
+website_url: https://docs.openreader.richardr.dev/
 source_code_url: https://github.com/richardr1126/openreader
 description: EPUB, PDF, DOCX, MD, and TXT file text to speech document reader. Read documents in realtime with high-quality TTS; or extract audiobooks.
 licenses:
@@ -8,7 +8,6 @@ platforms:
   - Docker
 tags:
   - Miscellaneous
-demo_url: https://openreader.richardr.dev/
 stargazers_count: 503
 updated_at: '2026-09-03'
 archived: false


### PR DESCRIPTION
OpenReader has geo-restricted their main webpage and demo to USA access only.
Update all references and links to point exclusively to the globally accessible documentation page instead of the geo-restricted page.