### PR TITLE
update descriptions to remove 'open-source'

### DIFF
--- a/software/amgix.yml
+++ b/software/amgix.yml
@@ -1,7 +1,7 @@
 name: Amgix
 website_url: https://amgix.io
 source_code_url: https://github.com/amgix/amgix-server
-description: Open-source hybrid search engine built for flexible deployment and real-world messy data.
+description: Hybrid search engine built for flexible deployment and real-world messy data.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/audiobookshelf.yml
+++ b/software/audiobookshelf.yml
@@ -1,6 +1,6 @@
 name: Audiobookshelf
 website_url: https://www.audiobookshelf.org/
-description: Audiobook and podcast server. It streams all audio formats, keeps and syncs progress across devices. Comes with open-source apps for Android and iOS.
+description: Audiobook and podcast server. It streams all audio formats, keeps and syncs progress across devices. Comes with apps for Android and iOS.
 licenses:
   - GPL-3.0
 platforms:

--- a/software/depay.yml
+++ b/software/depay.yml
@@ -1,6 +1,6 @@
 name: DePay
 website_url: https://depay.com
-description: Accept Web3 Payments directly into your wallet. Peer-to-peer, free, self-hosted & open-source.
+description: Accept Web3 Payments directly into your wallet peer-to-peer.
 licenses:
   - MIT
 platforms:

--- a/software/docassemble.yml
+++ b/software/docassemble.yml
@@ -1,6 +1,6 @@
 name: docassemble
 website_url: https://docassemble.org/
-description: A free, open-source expert system for guided interviews and document assembly, based on Python, YAML, and Markdown.
+description: System for guided interviews and document assembly, based on Python, YAML, and Markdown.
 licenses:
   - MIT
 platforms:

--- a/software/edx.yml
+++ b/software/edx.yml
@@ -1,6 +1,6 @@
 name: edX
 website_url: https://www.edx.org/
-description: The Open edX platform is open-source code that powers edX.org.
+description: Online learning platform that powers the edX.org website.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/espial.yml
+++ b/software/espial.yml
@@ -1,6 +1,6 @@
 name: Espial
 website_url: https://github.com/jonschoning/espial
-description: An open-source, web-based bookmarking server.
+description: Web-based bookmarking server that supports multiple user accounts.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/fusio.yml
+++ b/software/fusio.yml
@@ -1,6 +1,6 @@
 name: Fusio
 website_url: https://www.fusio-project.org/
-description: Open-source API management platform which helps to build and manage REST APIs.
+description: API management platform which helps to build and manage REST APIs.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/lowdefy.yml
+++ b/software/lowdefy.yml
@@ -1,6 +1,6 @@
 name: Lowdefy
 website_url: https://www.lowdefy.com/
-description: Build internal tools, BI dashboards, admin panels, CRUD apps and workflows in minutes using YAML / JSON on an self-hosted, open-source platform. Connect to your data sources, host via Serverless, Netlify or Docker.
+description: Build internal tools, BI dashboards, admin panels, CRUD apps and workflows in minutes using YAML / JSON.
 licenses:
   - Apache-2.0
 platforms:

--- a/software/opnform.yml
+++ b/software/opnform.yml
@@ -1,7 +1,7 @@
 name: OpnForm
 website_url: https://opnform.com
 source_code_url: https://github.com/OpnForm/OpnForm
-description: Beautiful open-source form builder.
+description: Beautiful form builder.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/plone.yml
+++ b/software/plone.yml
@@ -1,6 +1,6 @@
 name: Plone
 website_url: https://plone.org/
-description: Powerful open-source CMS system.
+description: CMS system that is used to create, edit, and manage digital content, like websites, intranets, and custom solutions.
 licenses:
   - ZPL-2.0
 platforms:

--- a/software/privmx-webmail.yml
+++ b/software/privmx-webmail.yml
@@ -1,6 +1,6 @@
 name: PrivMX WebMail
 website_url: https://privmx.com
-description: Alternative private mail system - web-based, end-to-end encrypted by design, self-hosted, decentralized, uses independent PKI. Easy to install and administrate, freeware, open-source.
+description: Web-based, end-to-end encrypted email platform that uses an independent PKI.
 licenses:
   - ⊘ Proprietary
 platforms:

--- a/software/reactive-resume.yml
+++ b/software/reactive-resume.yml
@@ -1,6 +1,6 @@
 name: Reactive Resume
 website_url: https://rxresu.me/
-description: One-of-a-kind resume builder that keeps your privacy in mind. Completely secure, customizable, portable, open-source and free forever.
+description: One-of-a-kind resume builder that keeps your privacy in mind. Completely secure, customizable and portable.
 licenses:
   - MIT
 platforms:

--- a/software/saleor.yml
+++ b/software/saleor.yml
@@ -1,6 +1,6 @@
 name: Saleor
 website_url: https://saleor.io
-description: Django based open-sourced e-commerce storefront.
+description: GraphQL native, API-only platform for scalable composable e-commerce storefront.
 licenses:
   - BSD-3-Clause
 platforms:

--- a/software/sharetribe.yml
+++ b/software/sharetribe.yml
@@ -1,6 +1,6 @@
 name: Sharetribe
 website_url: https://www.sharetribe.com
-description: Open-source platform to create your own peer-to-peer marketplace, also available with SaaS model.
+description: Platform to create your own peer-to-peer marketplace, also available with SaaS model.
 licenses:
   - ⊘ Proprietary
 platforms:

--- a/software/simpledms.yml
+++ b/software/simpledms.yml
@@ -1,7 +1,7 @@
 name: SimpleDMS
 website_url: https://simpledms.eu
 source_code_url: https://github.com/simpledms/simpledms
-description: Easy-to-use, metadata-driven, open-source document management system (DMS) for small businesses that sorts documents almost by itself.
+description: Easy-to-use, metadata-driven, document management system (DMS) for small businesses that sorts documents almost by itself.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/solidus.yml
+++ b/software/solidus.yml
@@ -1,6 +1,6 @@
 name: Solidus
 website_url: https://solidus.io/
-description: A free, open-source ecommerce platform that gives you complete control over your store.
+description: Ecommerce platform that gives you complete control over your store.
 licenses:
   - BSD-3-Clause
 platforms:

--- a/software/speed-test-by-openspeedtest™.yml
+++ b/software/speed-test-by-openspeedtest™.yml
@@ -1,6 +1,6 @@
 name: Speed Test by OpenSpeedTest™
 website_url: https://openspeedtest.com/
-description: Free & Open-Source HTML5 Network Performance Estimation Tool.
+description: HTML5 Network Performance Estimation Tool.
 licenses:
   - MIT
 platforms:

--- a/software/strapi.yml
+++ b/software/strapi.yml
@@ -1,6 +1,6 @@
 name: Strapi
 website_url: https://strapi.io/
-description: The most advanced open-source Content Management Framework (headless-CMS) to build powerful API with no effort.
+description: Headless CMS that lets developers build content APIs fast while giving content creators a friendly editing interface.
 licenses:
   - MIT
 platforms:

--- a/software/string.is.yml
+++ b/software/string.is.yml
@@ -1,6 +1,6 @@
 name: string.is
 website_url: https://string.is/
-description: An open-source, privacy-friendly online string toolkit for developers.
+description: Online string toolkit for developers.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/suroi.yml
+++ b/software/suroi.yml
@@ -1,7 +1,7 @@
 name: Suroi
 website_url: https://suroi.io/
 source_code_url: https://github.com/HasangerGames/suroi
-description: An open-source 2D battle royale game inspired by surviv.io.
+description: 2D battle royale game inspired by surviv.io.
 licenses:
   - GPL-3.0
 platforms:

--- a/software/svix.yml
+++ b/software/svix.yml
@@ -1,6 +1,6 @@
 name: Svix
 website_url: https://svix.com
-description: Open-source webhooks as a service that makes it super easy for API providers to send webhooks.
+description: Webhooks as a service that makes it super easy for API providers to send webhooks.
 licenses:
   - MIT
 platforms:

--- a/software/swetrix.yml
+++ b/software/swetrix.yml
@@ -1,6 +1,6 @@
 name: Swetrix
 website_url: https://swetrix.com/
-description: Ultimate, open-source web analytics to satisfy all your needs.
+description: Web analytics which track your site's traffic, monitor your site's speed, analyse user sessions and pageflows, see the user flows and more (alternative to Google Analytics).
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/thingsboard.yml
+++ b/software/thingsboard.yml
@@ -1,6 +1,6 @@
 name: Thingsboard
 website_url: https://thingsboard.io/
-description: Open-source IoT Platform - Device management, data collection, processing and visualization.
+description: IoT Platform - Device management, data collection, processing and visualization.
 licenses:
   - Apache-2.0
 platforms:

--- a/software/veloren.yml
+++ b/software/veloren.yml
@@ -1,6 +1,6 @@
 name: Veloren
 website_url: https://veloren.net/
-description: Multiplayer RPG. Open-source game inspired by Cube World, Legend of Zelda, Dwarf Fortress and Minecraft.
+description: Multiplayer RPG. Inspired by Cube World, Legend of Zelda, Dwarf Fortress and Minecraft.
 licenses:
   - GPL-3.0
 platforms:

--- a/software/wekan.yml
+++ b/software/wekan.yml
@@ -1,6 +1,6 @@
 name: Wekan
 website_url: https://wekan.github.io/
-description: Open-source Trello-like kanban.
+description: Trello-like kanban.
 licenses:
   - MIT
 platforms:

--- a/software/xbackbone.yml
+++ b/software/xbackbone.yml
@@ -1,6 +1,6 @@
 name: XBackBone
 website_url: https://xbackbone.app/
-description: A simple, fast and lightweight file manager with instant sharing tools integration, like ShareX (a free and open-source screenshot utility for Windows).
+description: Simple, fast and lightweight file manager with instant sharing tools integration, like ShareX.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/zammad.yml
+++ b/software/zammad.yml
@@ -1,6 +1,6 @@
 name: Zammad
 website_url: https://zammad.org/
-description: Easy to use but powerful open-source support and ticketing system.
+description: Easy to use but powerful support and ticketing system.
 licenses:
   - AGPL-3.0
 platforms:

--- a/software/zenko-cloudserver.yml
+++ b/software/zenko-cloudserver.yml
@@ -1,6 +1,6 @@
 name: Zenko CloudServer
 website_url: https://www.zenko.io/cloudserver
-description: Zenko CloudServer, an open-source implementation of a server handling the Amazon S3 protocol.
+description: Implementation of the Amazon S3 protocol on the front-end and backend storage capabilities to multiple clouds, including Azure and Google.
 licenses:
   - Apache-2.0
 platforms:

--- a/software/zenphoto.yml
+++ b/software/zenphoto.yml
@@ -1,6 +1,6 @@
 name: Zenphoto
 website_url: https://www.zenphoto.org/
-description: Open-source gallery and CMS project.
+description: Gallery and CMS project.
 licenses:
   - GPL-2.0
 platforms:


### PR DESCRIPTION
Removes any mentions of 'open-source' from all descriptions. Being open-source is already implied when listed here, and in some cases the the software wasn't even (libre-) free.