### PR TITLE
add Gigapipe

### DIFF
--- a/software/gigapipe.yml
+++ b/software/gigapipe.yml
@@ -1,0 +1,13 @@
+name: Gigapipe
+website_url: https://gigapipe.com
+source_code_url: https://github.com/metrico/gigapipe
+description: Polyglot observability warehouse for logs, metrics, traces and profiles on ClickHouse. Ingests OpenTelemetry, Loki, Prometheus, Tempo, Pyroscope, InfluxDB, Elastic and Datadog, served over LogQL, PromQL, TraceQL and FlameQL to Grafana or Perses.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Go
+  - Docker
+  - K8S
+tags:
+  - Monitoring & Status Pages
+demo_url: https://gigapipe.com/docs/demo


### PR DESCRIPTION
## add Gigapipe

Gigapipe is a polyglot observability warehouse for logs, metrics, traces and profiles, built on ClickHouse. It ingests the OpenTelemetry, Loki, Prometheus, Tempo, Pyroscope, InfluxDB, Elastic and Datadog formats, and serves the same data back over LogQL, PromQL, TraceQL and FlameQL, so existing Grafana or Perses dashboards work against it without plugins.

- Website: https://gigapipe.com
- Source: https://github.com/metrico/gigapipe
- Demo: https://gigapipe.com/docs/demo
- License: AGPL-3.0
- Language: Go

## Checklist

- [x] Submit one item per issue/PR.
- [x] Searched the repository for relevant issues and PRs, including closed ones. No existing entry for Gigapipe or its former name, qryn.
- [x] Not listed at awesome-sysadmin, staticgen.com, staticsitegenerators.bevry.me or dbdb.io.
- [x] Actively maintained — most recent commit 2026-09-03, continuous history.
- [x] First released more than 4 months ago — the repository dates to 2018 and the project was previously known as qryn.
- [x] Working installation instructions — Docker, Kubernetes and binary, documented at https://gigapipe.com/docs/oss.

## Notes

- `tags` uses `Monitoring & Status Pages`, the closest existing category. There is no observability tag, and I have not proposed one, since a new tag needs at least three projects behind it.
- `description` is 245 characters, within the 250 limit.
- Self-hostable in full: the AGPL-3.0 release is the same engine as the hosted offering, and requires no third-party service, so `depends_3rdparty` is not set.

## Disclosure

I work at Gigapipe.
