### PR TITLE
Add Darkroom Log

### DIFF
--- a/software/darkroom-log.yml
+++ b/software/darkroom-log.yml
@@ -1,0 +1,13 @@
+name: "Darkroom Log"
+website_url: "https://github.com/jaapjan14/darkroom-log"
+source_code_url: "https://github.com/jaapjan14/darkroom-log"
+description: "Logs darkroom print sessions (paper, exposure, dodge/burn) and browses/shares an Immich photo library via public albums and slideshows."
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Photo Galleries
+depends_3rdparty: false
+related_software_url: "https://github.com/immich-app/immich"


### PR DESCRIPTION
Thanks for taking the time to suggest an addition to awesome-selfhosted!

To ensure your Pull Request is dealt with swiftly, please check the following (check the boxes `[x]`):
- [x] Submit one item per pull request. This eases reviewing and speeds up inclusion.
- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pulls), including closed ones.
- [x] Any software you are adding is not already listed at any of [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.bevry.me](https://staticsitegenerators.bevry.me/), [dbdb.io](https://dbdb.io/browse).
- [x] The file you are adding is formatted as described in [addition.md](https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/ISSUE_TEMPLATE/addition.md).
- [x] `Demo` links should only be used for interactive demos, i.e. not video demonstrations. If login credentials are required to access the demo, please link to the credentials directly.
- [x] Comments and unused optional fields have been removed.
- [x] The file you are adding uses [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) file naming, for example `my-awesome-software.yml`.
- [x] Values for `platform` should match the platforms required to install and run the software.
- [x] Any software project you are adding to the list is actively maintained.
- [x] Any software project you are adding was first released more than 4 months ago.
- [x] Any software project you are adding has working installation instructions.
- [x] You understand that your Pull Request will be merged at least ~1 week after approval, depending on maintainers time.

Darkroom Log pairs a wet-darkroom print logbook (paper, enlarger height, aperture, exposure time, contrast grade, dodge/burn notes) with an Immich-backed photo library viewer — browsing, filtering, and curated albums with shareable public links, each with a Ken Burns slideshow, on top of a self-hosted Immich instance. Includes some sort/filter options Immich's own UI doesn't offer natively (e.g. sorting albums by upload vs. taken date).

Built through human+AI pair-programming (see the README's Credits section) — I provided the vision, domain expertise, and testing; Claude assisted with implementation.

First released 2026-04-13, currently on v1.5.101. Tagged `Photo Galleries` to match Immich Kiosk, the closest existing companion-app entry for Immich.