### PR TITLE
Add AppCrane

### DIFF
--- a/software/appcrane.yml
+++ b/software/appcrane.yml
@@ -1,0 +1,11 @@
+name: AppCrane
+website_url: https://glick.run/appcrane.html
+source_code_url: https://github.com/gitayg/appCrane
+description: Self-hosted, agent-native platform-as-a-service: deploy and run the apps your AI builds on one server, driven by an AI agent over the Model Context Protocol. Docker isolation, auto-HTTPS, GitHub-native deploys, rollback, SSO and per-user audit.
+licenses:
+  - AGPL-3.0
+platforms:
+  - Docker
+tags:
+  - Self-hosting Solutions
+  - Software Development - Continuous Integration & Deployment


### PR DESCRIPTION
Adds **AppCrane** — a self-hosted, agent-native platform-as-a-service.

- **Website:** https://glick.run/appcrane.html
- **Source:** https://github.com/gitayg/appCrane
- **License:** AGPL-3.0
- **Platform:** Docker

Guideline checklist:
- [x] Self-hostable and open source (AGPL-3.0)
- [x] First release (v1.0.62) published 2026-04-12 — more than 4 months ago
- [x] Actively developed (60 releases; latest v2.6x)
- [x] Description 60–250 chars, does not contain the software name, ends with a period
- [x] Tags reference existing categories (Self-hosting Solutions; Software Development - Continuous Integration & Deployment)