### PR TITLE
fix manifest source_code_url

### DIFF
--- a/software/manifest.yml
+++ b/software/manifest.yml
@@ -7,7 +7,7 @@ platforms:
   - Nodejs
 tags:
   - Software Development - Low Code
-source_code_url: https://github.com/mnfst/manifest
+source_code_url: https://github.com/mnfst/llm-gateway
 demo_url: https://manifest.new
 stargazers_count: 7511
 updated_at: '2026-09-08'


### PR DESCRIPTION
`ERROR:software_metadata.py: repository not found in search results: https://github.com/mnfst/manifest`