### PR TITLE
fix source_code_url reactive resume

### DIFF
--- a/software/reactive-resume.yml
+++ b/software/reactive-resume.yml
@@ -8,7 +8,7 @@ platforms:
   - Nodejs
 tags:
   - Miscellaneous
-source_code_url: https://github.com/AmruthPillai/Reactive-Resume
+source_code_url: https://github.com/reactive-resume/reactive-resume
 demo_url: https://rxresu.me/
 stargazers_count: 42439
 updated_at: '2026-09-10'


### PR DESCRIPTION
- https://github.com/awesome-selfhosted/awesome-selfhosted-data/actions/runs/34661341517/job/103464309499
- `ERROR:software_metadata.py: repository not found in search results: https://github.com/AmruthPillai/Reactive-Resume`